### PR TITLE
Update base image and libraries

### DIFF
--- a/docker/jupyter-scipy-notebook-ee/Dockerfile
+++ b/docker/jupyter-scipy-notebook-ee/Dockerfile
@@ -1,61 +1,61 @@
-FROM jupyter/scipy-notebook:92fe05d1e7e5
+FROM jupyter/scipy-notebook:59904dd7776a
+LABEL base-image="jupyter/scipy-notebook:59904dd7776a 6/6/2018"
 
 LABEL maintainer="Tyler Erickson <tylere@google.com>"
 
 USER root
 
-# Upgrade JupyterLab
-RUN conda install jupyterlab==0.31.12
+RUN conda install -c conda-forge \
+  ipywidgets \
+  altair \
+  vega_datasets
+
+# Install nbgitpuller (Notebook Git Puller).
+# https://github.com/data-8/nbgitpuller
+RUN pip install git+https://github.com/data-8/nbgitpuller \
+  && jupyter serverextension enable --py nbgitpuller --sys-prefix
+
+# Install the JupyterLab Sidecar.
+# https://github.com/jupyter-widgets/jupyterlab-sidecar
+RUN pip install sidecar
+
+# Install ipyleaflet (Leaflet-based interactiving mapping widget).
+# https://github.com/jupyter-widgets/ipyleaflet
+ARG IPYLEAFLET_VERSION=0.8.1
+RUN pip install ipyleaflet==$IPYLEAFLET_VERSION \
+  && jupyter nbextension enable --py --sys-prefix ipyleaflet \
+  && jupyter labextension install --no-build jupyter-leaflet@0.8.1
 
 # Install bqplot.
-#   https://github.com/bloomberg/bqplot
-RUN pip install bqplot==0.10.5 \
+# https://github.com/bloomberg/bqplot
+ARG BQPLOT_VERSION=0.10.1
+RUN pip install bqplot==$BQPLOT_VERSION \
   && jupyter nbextension install bqplot --py --symlink --sys-prefix \
   && jupyter nbextension enable --py --sys-prefix bqplot \
-  && jupyter labextension install bqplot
+  && jupyter labextension install --no-build bqplot
 
-# Install ipyleaflet.
-#   https://github.com/ellisonbg/ipyleaflet
-RUN pip install ipyleaflet==0.7.3 \
-  && jupyter nbextension enable --py --sys-prefix ipyleaflet \
-  && jupyter labextension install jupyter-leaflet
+# Install nbdime (Notebook Diff & Merge tool).
+# https://github.com/jupyter/nbdime
+RUN pip install nbdime 
 
-# Install Altair.
-#   https://github.com/altair-viz/jupyter_vega
-RUN pip install altair==2.0.0rc1 \
-  && pip install --upgrade notebook \
-  && jupyter labextension install @jupyterlab/vega3-extension
+# Install the Table of Contents extension.
+RUN jupyter labextension install  --no-build jupyterlab-toc
 
-# Install sample Vega datasets.
-RUN pip install vega_datasets
+# Build all the JupyterLab extensions.
+RUN jupyter lab build
 
-# Install Palettable (color maps)
-RUN pip install palettable
+# Install ipythonblocks (colored grids) and Palettable (color maps)
+RUN pip install ipythonblocks \
+  && pip install palettable
 
-# Install the Earth Engine Python API.
-#   https://github.com/google/earthengine-api
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-             build-essential \
-             libssl-dev \
-             libffi-dev \
-  && pip install cryptography \
-  && pip install earthengine-api \
-  && apt-get purge -y build-essential \
-             libssl-dev \
-             libffi-dev \
-             dpkg-dev \
-             fakeroot \
-             libfakeroot:amd64 \
-  && apt-get autoremove -y \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+# Install Tensorflow. (https://www.tensorflow.org/)
+RUN pip install tensorflow
+
+# Install the Earth Engine Python API. (https://github.com/google/earthengine-api)
+RUN conda install -c conda-forge earthengine-api
+
+# Install libraries for working with Google tools.
+RUN pip install PyDrive \
+  && pip install --upgrade google-cloud
 
 USER $NB_USER
-
-# Make sure contents are in HOME and owned by the non-root user, which is required by Binder.
-# http://mybinder.readthedocs.io/en/latest/dockerfile.html#preparing-your-dockerfile
-COPY . ${HOME}
-USER root
-RUN chown -R ${NB_UID} ${HOME}
-USER ${NB_USER}

--- a/docker/jupyter-scipy-notebook-ee/Dockerfile
+++ b/docker/jupyter-scipy-notebook-ee/Dockerfile
@@ -1,14 +1,82 @@
-FROM jupyter/scipy-notebook:59904dd7776a
-LABEL base-image="jupyter/scipy-notebook:59904dd7776a 6/6/2018"
+FROM jupyter/scipy-notebook:03b897d05f16
+LABEL base-image="jupyter/scipy-notebook:03b897d05f16 6/13/2018"
 
 LABEL maintainer="Tyler Erickson <tylere@google.com>"
 
 USER root
 
+# ipyleaflet - Leaflet-based interactiving mapping widget
+#     docs: https://ipyleaflet.readthedocs.io
+#   source: https://github.com/jupyter-widgets/ipyleaflet
+#     pkgs: conda search -c conda-forge ipyleaflet
+ARG IPYLEAFLET_VERSION=0.8.4
+
+# ipywidgets - Interactive Widgets for the Jupyter Notebook
+#     docs: https://ipywidgets.readthedocs.io
+#   source: https://github.com/jupyter-widgets/ipywidgets
+#     pkgs: conda search -c conda-forge ipywidgets
+ARG IPYWIDGETS_VERSION=7.2.1
+
+# Altair - Declarative visualization in Python
+#     docs: https://altair-viz.github.io
+#   source: https://github.com/altair-viz/altair
+#     pkgs: conda search -c conda-forge altair
+ARG ALTAIR_VERSION=2.1.0
+
+# Vega Datasets - Collection of datasets used in Vega and Vega-Lite examples
+#     docs: http://vega.github.io/vega-datasets
+#   source: https://github.com/vega/vega-datasets
+#     pkgs: source: https://github.com/vega/vega-datasets
+ARG VEGA_DATASETS_VERSION=0.5.0
+
+# bqplot - Grammar of Graphics-based interactive plotting framework for the Jupyter notebook
+#     docs: https://bqplot.readthedocs.io
+#   source: https://github.com/bloomberg/bqplot
+#     pkgs: conda search -c conda-forge bqplot
+ARG BQPLOT_VERSION=0.10.5
+
+# nbdime - Notebook Diff & Merge tool
+#     docs: https://nbdime.readthedocs.io
+#   source: https://github.com/jupyter/nbdime
+#     pkgs: conda search -c conda-forge nbdime
+ARG NBDIME_VERSION=1.0.1
+
+# Palettable - color maps
+#     docs: https://jiffyclub.github.io/palettable
+#   source: https://github.com/jiffyclub/palettable
+#     pkgs: conda search -c conda-forge palettable
+ARG PALETTABLE_VERSION=3.1.1
+
+# TensorFlow - Computation using data flow graphs for scalable machine learning
+#     home: https://www.tensorflow.org
+#     docs: https://www.tensorflow.org/api_docs
+#   source: https://github.com/tensorflow/tensorflow
+#     pkgs: conda search -c conda-forge tensorflow
+ARG TENSORFLOW_VERSION=1.8.0
+
+# Earth Engine Python API 
+#     home: https://earthengine.google.com
+#     docs: https://developers.google.com/earth-engine
+#   source: https://github.com/google/earthengine-api
+#     pkgs: conda search -c conda-forge earthengine-api
+ARG EARTHENGINE_API_VERSION=0.1.141
+
 RUN conda install -c conda-forge \
-  ipywidgets \
-  altair \
-  vega_datasets
+  ipywidgets=$IPYWIDGETS_VERSION \
+  ipyleaflet=$IPYLEAFLET_VERSION \
+  altair=$ALTAIR_VERSION \
+  vega_datasets=$VEGA_DATASETS_VERSION \
+  bqplot=$BQPLOT_VERSION \
+  nbdime=$NBDIME_VERSION \
+  palettable=$PALETTABLE_VERSION \
+  tensorflow=$TENSORFLOW_VERSION \
+  earthengine-api=$EARTHENGINE_API_VERSION
+
+# Enable JupyterLab extensions.
+RUN jupyter labextension install --no-build \
+  jupyter-leaflet \
+  bqplot \
+  jupyterlab-toc
 
 # Install nbgitpuller (Notebook Git Puller).
 # https://github.com/data-8/nbgitpuller
@@ -19,40 +87,11 @@ RUN pip install git+https://github.com/data-8/nbgitpuller \
 # https://github.com/jupyter-widgets/jupyterlab-sidecar
 RUN pip install sidecar
 
-# Install ipyleaflet (Leaflet-based interactiving mapping widget).
-# https://github.com/jupyter-widgets/ipyleaflet
-ARG IPYLEAFLET_VERSION=0.8.1
-RUN pip install ipyleaflet==$IPYLEAFLET_VERSION \
-  && jupyter nbextension enable --py --sys-prefix ipyleaflet \
-  && jupyter labextension install --no-build jupyter-leaflet@0.8.1
-
-# Install bqplot.
-# https://github.com/bloomberg/bqplot
-ARG BQPLOT_VERSION=0.10.1
-RUN pip install bqplot==$BQPLOT_VERSION \
-  && jupyter nbextension install bqplot --py --symlink --sys-prefix \
-  && jupyter nbextension enable --py --sys-prefix bqplot \
-  && jupyter labextension install --no-build bqplot
-
-# Install nbdime (Notebook Diff & Merge tool).
-# https://github.com/jupyter/nbdime
-RUN pip install nbdime 
-
-# Install the Table of Contents extension.
-RUN jupyter labextension install  --no-build jupyterlab-toc
-
 # Build all the JupyterLab extensions.
 RUN jupyter lab build
 
-# Install ipythonblocks (colored grids) and Palettable (color maps)
-RUN pip install ipythonblocks \
-  && pip install palettable
-
-# Install Tensorflow. (https://www.tensorflow.org/)
-RUN pip install tensorflow
-
-# Install the Earth Engine Python API. (https://github.com/google/earthengine-api)
-RUN conda install -c conda-forge earthengine-api
+# Install ipythonblocks (colored grids)
+RUN pip install ipythonblocks 
 
 # Install libraries for working with Google tools.
 RUN pip install PyDrive \

--- a/docker/jupyter-scipy-notebook-ee/test_jupyter_scipy_notebook_ee.ipynb
+++ b/docker/jupyter-scipy-notebook-ee/test_jupyter_scipy_notebook_ee.ipynb
@@ -4,17 +4,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Summary\n",
+    "# Overview\n",
     "\n",
-    "This is a notebook for basic manual testing of the packages installed by the Docker image."
+    "The purpose of this notebooks is to run simple tests on the libraries provided by the Docker image [Jupyter Notebook Scientific Python Stack + Earth Engine](https://github.com/gee-community/ee-jupyter-contrib/tree/master/docker/jupyter-scipy-notebook-ee)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Test ipywidgets\n",
-    "https://github.com/jupyter-widgets/ipywidgets"
+    "# Earth Engine Packages\n",
+    "\n",
+    "## Earth Engine Python API\n",
+    "\n",
+    "\"The Earth Engine Python API is a client library that facilitates interacting with the Earth Engine servers using the Python programming language.\" \n",
+    "\n",
+    "* Homepage: https://earthengine.google.com/\n",
+    "* Docs: https://developers.google.com/earth-engine/\n",
+    "* Source code: https://github.com/google/earthengine-api"
    ]
   },
   {
@@ -23,7 +30,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ipywidgets"
+    "import ee\n",
+    "print(ee.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Jupyter Project packages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Jupyter Notebook\n",
+    "\n",
+    "The core library for Jupyter Interactive Notebooks.\n",
+    "\n",
+    "* Docs: https://jupyter-notebook.readthedocs.io/\n",
+    "* Source code: https://github.com/jupyter/notebook"
    ]
   },
   {
@@ -32,16 +59,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ipywidgets.IntSlider()"
+    "import notebook\n",
+    "print(notebook.__version__)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Test bqplot\n",
+    "## JupyterHub\n",
     "\n",
-    "https://github.com/bloomberg/bqplot"
+    "\"JupyterHub, a multi-user Hub, spawns, manages, and proxies multiple instances of the single-user Jupyter notebook server.\"\n",
+    "\n",
+    "* Docs: https://jupyterhub.readthedocs.io\n",
+    "* Source code: https://github.com/jupyterhub/jupyterhub"
    ]
   },
   {
@@ -50,24 +81,83 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bqplot import pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "plt.figure(1, title='Line Chart')\n",
-    "np.random.seed(0)\n",
-    "n = 200\n",
-    "x = np.linspace(0.0, 10.0, n)\n",
-    "y = np.cumsum(np.random.randn(n))\n",
-    "plt.plot(x, y)\n",
-    "plt.show()"
+    "import jupyterhub\n",
+    "print(jupyterhub.__version__)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Test ipyleaflet\n",
-    "https://github.com/ellisonbg/ipyleaflet"
+    "## JupyterLab\n",
+    "\n",
+    "\"JupyterLab computational environment.\"\n",
+    "\n",
+    "* Docs: http://jupyterlab.readthedocs.io\n",
+    "* Source code: https://github.com/jupyterlab/jupyterlab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jupyterlab\n",
+    "print(jupyterlab.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Jupyter Notebook Widgets\n",
+    "\n",
+    "\"Widgets are eventful python objects that have a representation in the browser, often as a control like a slider, textbox, etc.\"\n",
+    "\n",
+    "* Homepage: http://jupyter.org/widgets\n",
+    "* Docs: https://ipywidgets.readthedocs.io\n",
+    "* Source code: https://github.com/jupyter-widgets/ipywidgets\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets\n",
+    "print(ipywidgets.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_slider= ipywidgets.widgets.IntSlider()\n",
+    "display(my_slider)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_slider.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ipyleaflet\n",
+    "\n",
+    "ipyleaflet is a Jupyter Widget for interactive mapping, based on the [Leaflet](https://leafletjs.com/) Javascript library.\n",
+    "\n",
+    "* Source code: https://github.com/jupyter-widgets/ipyleaflet"
    ]
   },
   {
@@ -77,17 +167,29 @@
    "outputs": [],
    "source": [
     "import ipyleaflet\n",
-    "\n",
-    "ipyleaflet.Map(center=[34.62, -77.34], zoom=10)"
+    "print(ipyleaflet.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_map = ipyleaflet.Map(center=(53.35, -6.2), zoom=11)\n",
+    "my_map"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Test the Earth Engine Python API\n",
+    "### bqplot\n",
     "\n",
-    "https://github.com/google/earthengine-api"
+    "\"bqplot is a Grammar of Graphics-based interactive plotting framework for the Jupyter notebook.\" \n",
+    "\n",
+    "* Docs: https://bqplot.readthedocs.io/en/stable/\n",
+    "* Source code: https://github.com/bloomberg/bqplot"
    ]
   },
   {
@@ -96,16 +198,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from IPython.display import Image\n",
-    "import ee\n",
-    "\n",
-    "# Note that you need to authenticate the server before initializing the package\n",
-    "# by running the following command in a terminal: earthengine authenticate\n",
-    "ee.Initialize()\n",
-    "\n",
-    "# Generate a URL that displays a global DEM.\n",
-    "url = ee.Image(\"USGS/SRTMGL1_003\").getThumbUrl({'min':0, 'max':3000})\n",
-    "Image(url=url)"
+    "import bqplot\n",
+    "print(bqplot.__version__)"
    ]
   },
   {
@@ -113,7 +207,333 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import numpy as np\n",
+    "size = 100\n",
+    "x_data = range(size)\n",
+    "np.random.seed(0)\n",
+    "y_data = np.cumsum(np.random.randn(size) * 100.0)\n",
+    "y_data_2 = np.cumsum(np.random.randn(size))\n",
+    "y_data_3 = np.cumsum(np.random.randn(size) * 100.)\n",
+    "\n",
+    "sc_ord = bqplot.OrdinalScale()\n",
+    "sc_y = bqplot.LinearScale()\n",
+    "sc_y_2 = bqplot.LinearScale()\n",
+    "\n",
+    "ord_ax = bqplot.Axis(label='Test X', scale=sc_ord, tick_format='0.0f', grid_lines='none')\n",
+    "y_ax = bqplot.Axis(label='Test Y', scale=sc_y, \n",
+    "            orientation='vertical', tick_format='0.2f', \n",
+    "            grid_lines='solid')\n",
+    "y_ax_2 = bqplot.Axis(label='Test Y 2', scale=sc_y_2, \n",
+    "              orientation='vertical', side='right', \n",
+    "              tick_format='0.0f', grid_lines='solid')\n",
+    "\n",
+    "line_chart  = bqplot.Lines(x=x_data[:10], y = [y_data[:10], y_data_2[:10] * 100, y_data_3[:10]],\n",
+    "                   scales={'x': sc_ord, 'y': sc_y},\n",
+    "                   labels=['Line1', 'Line2', 'Line3'], \n",
+    "                   display_legend=True)\n",
+    "\n",
+    "bar_chart = bqplot.Bars(x=x_data[:10], \n",
+    "                 y=[y_data[:10], y_data_2[:10] * 100, y_data_3[:10]], \n",
+    "                 scales={'x': sc_ord, 'y': sc_y_2},\n",
+    "                 labels=['Bar1', 'Bar2', 'Bar3'],\n",
+    "                 display_legend=True)\n",
+    "\n",
+    "# the line does not have a Y value set. So only the bars will be displayed\n",
+    "bqplot.Figure(axes=[ord_ax, y_ax],  marks=[bar_chart, line_chart], legend_location = 'bottom-left')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## JupyterLab Sidecar\n",
+    "\n",
+    "\"A sidecar output widget for JupyterLab\" \n",
+    "\n",
+    "* Source code: https://github.com/jupyter-widgets/jupyterlab-sidecar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sidecar\n",
+    "print(sidecar.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import IntSlider\n",
+    "\n",
+    "sc = sidecar.Sidecar(title='Sidecar Output')\n",
+    "sl = IntSlider(description='Some slider')\n",
+    "with sc:\n",
+    "    display(sl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## nbdime\n",
+    "\n",
+    "\"Jupyter Notebook Diff & Merge tools\"\n",
+    "\n",
+    "* docs: https://nbdime.readthedocs.io\n",
+    "* source: https://github.com/jupyter/nbdime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nbdime\n",
+    "print(nbdime.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualization packages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ipythonblocks\n",
+    "\n",
+    "\"Practice Python with colored grids in the IPython Notebook\"\n",
+    "\n",
+    "* Homepage: http://www.ipythonblocks.org\n",
+    "* Source code: https://github.com/jiffyclub/ipythonblocks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipythonblocks\n",
+    "print(ipythonblocks.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = ipythonblocks.BlockGrid(10, 10, fill=(123, 234, 123))\n",
+    "grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Palettable\n",
+    "\n",
+    "\"Palettable is a library of color palettes for Python.\" \n",
+    "\n",
+    "* Docs: https://jiffyclub.github.io/palettable/\n",
+    "* Source code: https://github.com/jiffyclub/palettable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import palettable\n",
+    "print(palettable.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from matplotlib.colors import LogNorm\n",
+    "from palettable.colorbrewer.sequential import YlGnBu_9\n",
+    "\n",
+    "#normal distribution center at x=0 and y=5\n",
+    "x = np.random.randn(100000)\n",
+    "y = np.random.randn(100000)+5\n",
+    "\n",
+    "plt.hist2d(x, y, bins=40, norm=LogNorm(), cmap=YlGnBu_9.mpl_colormap)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Altair\n",
+    "\n",
+    "\"Altair is a declarative statistical visualization library for Python.\" \n",
+    "\n",
+    "* Docs: https://altair-viz.github.io/\n",
+    "* Source code: https://github.com/altair-viz/altair\n",
+    "* Tutorials: https://github.com/altair-viz/altair_notebooks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import altair as alt\n",
+    "print(alt.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load a simple dataset as a pandas DataFrame\n",
+    "from vega_datasets import data\n",
+    "cars = data.cars()\n",
+    "\n",
+    "alt.Chart(cars).mark_point().encode(\n",
+    "    x='Horsepower',\n",
+    "    y='Miles_per_Gallon',\n",
+    "    color='Origin',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PILLOW\n",
+    "\n",
+    "\"Pillow is the friendly PIL fork by Alex Clark and Contributors. PIL is the Python Imaging Library by Fredrik Lundh and Contributors.\"\n",
+    "\n",
+    "* Docs: http://pillow.readthedocs.io"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import PIL\n",
+    "print(PIL.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## imageio\n",
+    "\n",
+    "\"Imageio is a Python library that provides an easy interface to read and write a wide range of image data, including animated images, video, volumetric data, and scientific formats.\"\n",
+    "\n",
+    "* Home: https://imageio.github.io/\n",
+    "* Docs: http://imageio.readthedocs.io/\n",
+    "* Source Code: https://github.com/imageio/imageio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Machine Learning\n",
+    "\n",
+    "## Tensorflow\n",
+    "\n",
+    "\"Computation using data flow graphs for scalable machine learning\"\n",
+    "\n",
+    "Homepage: https://www.tensorflow.org/\n",
+    "Docs: https://www.tensorflow.org/api_docs/python/\n",
+    "Source code: https://github.com/tensorflow/tensorflow\n",
+    "Tutorials: https://www.tensorflow.org/tutorials/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "print(tf.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tensorflow.python.keras.datasets import mnist\n",
+    "from tensorflow.python.keras.models import Sequential\n",
+    "from tensorflow.python.keras.layers import Dense, Dropout\n",
+    "from tensorflow.python.keras.optimizers import RMSprop\n",
+    "from tensorflow.python import keras\n",
+    "\n",
+    "batch_size = 128\n",
+    "num_classes = 10\n",
+    "epochs = 2\n",
+    "\n",
+    "# the data, split between train and test sets\n",
+    "(x_train, y_train), (x_test, y_test) = mnist.load_data()\n",
+    "\n",
+    "x_train = x_train.reshape(60000, 784)\n",
+    "x_test = x_test.reshape(10000, 784)\n",
+    "x_train = x_train.astype('float32')\n",
+    "x_test = x_test.astype('float32')\n",
+    "x_train /= 255\n",
+    "x_test /= 255\n",
+    "print(x_train.shape[0], 'train samples')\n",
+    "print(x_test.shape[0], 'test samples')\n",
+    "\n",
+    "# convert class vectors to binary class matrices\n",
+    "y_train = keras.utils.to_categorical(y_train, num_classes)\n",
+    "y_test = keras.utils.to_categorical(y_test, num_classes)\n",
+    "\n",
+    "model = Sequential()\n",
+    "model.add(Dense(512, activation='relu', input_shape=(784,)))\n",
+    "model.add(Dropout(0.2))\n",
+    "model.add(Dense(512, activation='relu'))\n",
+    "model.add(Dropout(0.2))\n",
+    "model.add(Dense(num_classes, activation='softmax'))\n",
+    "\n",
+    "model.summary()\n",
+    "\n",
+    "model.compile(loss='categorical_crossentropy',\n",
+    "              optimizer=RMSprop(),\n",
+    "              metrics=['accuracy'])\n",
+    "\n",
+    "history = model.fit(x_train, y_train,\n",
+    "                    batch_size=batch_size,\n",
+    "                    epochs=epochs,\n",
+    "                    verbose=1,\n",
+    "                    validation_data=(x_test, y_test))\n",
+    "score = model.evaluate(x_test, y_test, verbose=0)\n",
+    "print('Test loss:', score[0])\n",
+    "print('Test accuracy:', score[1])"
+   ]
   }
  ],
  "metadata": {
@@ -132,7 +552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
JupyterLab - use the version contained in the docker stacks jupyter/scipy-notebook image
ipywidgets - use the conda-forge version
altair - use the conda-forge version
bqplot - update to 0.10.5
earthengine - use the conda-forge version
new packages: nbdime, jupyterlab-toc, ipythonblocks, tensorflow, PyDrive