### PR TITLE
Update base image and package versions

### DIFF
--- a/docker/jupyter-scipy-notebook-ee/Dockerfile
+++ b/docker/jupyter-scipy-notebook-ee/Dockerfile
@@ -1,5 +1,5 @@
-FROM jupyter/scipy-notebook:5811dcb711ba
-LABEL base-image="jupyter/scipy-notebook:5811dcb711ba 6/23/2018"
+FROM jupyter/scipy-notebook:177037d09156
+LABEL base-image="jupyter/scipy-notebook:177037d09156 8/6/2018"
 
 LABEL maintainer="Tyler Erickson <tylere@google.com>"
 
@@ -24,20 +24,20 @@ ARG ALTAIR_VERSION=2.1.0
 # Vega Datasets - Collection of datasets used in Vega and Vega-Lite examples
 #     docs: http://vega.github.io/vega-datasets
 #   source: https://github.com/vega/vega-datasets
-#     pkgs: source: https://github.com/vega/vega-datasets
+#     pkgs: conda search -c conda-forge vega_datasets
 ARG VEGA_DATASETS_VERSION=0.5.0
 
 # bqplot - Grammar of Graphics-based interactive plotting framework for the Jupyter notebook
 #     docs: https://bqplot.readthedocs.io
 #   source: https://github.com/bloomberg/bqplot
 #     pkgs: conda search -c conda-forge bqplot
-ARG BQPLOT_VERSION=0.10.5
+ARG BQPLOT_VERSION=0.11.0
 
 # nbdime - Notebook Diff & Merge tool
 #     docs: https://nbdime.readthedocs.io
 #   source: https://github.com/jupyter/nbdime
 #     pkgs: conda search -c conda-forge nbdime
-ARG NBDIME_VERSION=1.0.1
+ARG NBDIME_VERSION=1.0.2
 
 # Palettable - color maps
 #     docs: https://jiffyclub.github.io/palettable
@@ -64,7 +64,7 @@ ARG TENSORFLOW_VERSION=1.8.0
 #     docs: https://developers.google.com/earth-engine
 #   source: https://github.com/google/earthengine-api
 #     pkgs: conda search -c conda-forge earthengine-api
-ARG EARTHENGINE_API_VERSION=0.1.143
+ARG EARTHENGINE_API_VERSION=0.1.145
 
 # Google API Python Client 
 #     home: http://google.github.io/google-api-python-client/
@@ -88,25 +88,25 @@ ARG GOOGLE_API_PYTHON_VERSION=1.6.7
 #    home: http://www.ipythonblocks.org/
 
 RUN conda install --quiet --yes \
-        ipyleaflet=${IPYLEAFLET_VERSION} \
         altair=${ALTAIR_VERSION} \
-        vega_datasets=${VEGA_DATASETS_VERSION} \
         bqplot=${BQPLOT_VERSION} \
+        earthengine-api=${EARTHENGINE_API_VERSION} \
+        google-api-python-client=${GOOGLE_API_PYTHON_VERSION} \
+        ipyleaflet=${IPYLEAFLET_VERSION} \
         nbdime=${NBDIME_VERSION} \
         palettable=${PALETTABLE_VERSION} \
         pydrive=${PYDRIVE_VERSION} \
         tensorflow=${TENSORFLOW_VERSION} \
-        earthengine-api=${EARTHENGINE_API_VERSION} \
-        google-api-python-client=${GOOGLE_API_PYTHON_VERSION} \
+        vega_datasets=${VEGA_DATASETS_VERSION} \
       && \
     conda clean -tipsy && \
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # JupyterLab Extensions
     pip install sidecar && \
     jupyter labextension install --no-build jupyter-leaflet@0.9.0 && \
-    jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager@0.35 && \
+    jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager@0.36.1 && \
     jupyter labextension install --no-build bqplot && \
-    jupyter labextension install --no-build jupyterlab-toc && \
+    jupyter labextension install --no-build @jupyterlab/toc && \
     pip install git+https://github.com/data-8/nbgitpuller \
       && jupyter serverextension enable --py nbgitpuller --sys-prefix && \
     pip install ipythonblocks && \

--- a/docker/jupyter-scipy-notebook-ee/test_jupyter_scipy_notebook_ee.ipynb
+++ b/docker/jupyter-scipy-notebook-ee/test_jupyter_scipy_notebook_ee.ipynb
@@ -26,9 +26,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.1.145\n"
+     ]
+    }
+   ],
    "source": [
     "import ee\n",
     "print(ee.__version__)"
@@ -55,9 +63,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5.6.0\n"
+     ]
+    }
+   ],
    "source": [
     "import notebook\n",
     "print(notebook.__version__)"
@@ -77,9 +93,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.9.1\n"
+     ]
+    }
+   ],
    "source": [
     "import jupyterhub\n",
     "print(jupyterhub.__version__)"
@@ -99,9 +123,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.33.7\n"
+     ]
+    }
+   ],
    "source": [
     "import jupyterlab\n",
     "print(jupyterlab.__version__)"
@@ -122,9 +154,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7.2.1\n"
+     ]
+    }
+   ],
    "source": [
     "import ipywidgets\n",
     "print(ipywidgets.__version__)"
@@ -132,9 +172,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "726d9811e01243fb9ac902707e7541ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntSlider(value=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "my_slider= ipywidgets.widgets.IntSlider()\n",
     "display(my_slider)"
@@ -142,9 +197,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "my_slider.value"
    ]
@@ -162,9 +228,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.9.0\n"
+     ]
+    }
+   ],
    "source": [
     "import ipyleaflet\n",
     "print(ipyleaflet.__version__)"
@@ -172,9 +246,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0fa8063454274181ae4956c00c7c5e24",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(basemap={'url': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', 'max_zoom': 19, 'attribution': 'Map …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "my_map = ipyleaflet.Map(center=(53.35, -6.2), zoom=11)\n",
     "my_map"
@@ -194,9 +283,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.11.0\n"
+     ]
+    }
+   ],
    "source": [
     "import bqplot\n",
     "print(bqplot.__version__)"
@@ -204,9 +301,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ee0a5362327d47a884d81fb6c146961e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Figure(axes=[Axis(grid_lines='none', label='Test X', scale=OrdinalScale(), tick_format='0.0f'), Axis(label='Te…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "size = 100\n",
@@ -256,9 +368,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.1.0.dev\n"
+     ]
+    }
+   ],
    "source": [
     "import sidecar\n",
     "print(sidecar.__version__)"
@@ -266,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,9 +412,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.0.2\n"
+     ]
+    }
+   ],
    "source": [
     "import nbdime\n",
     "print(nbdime.__version__)"
@@ -321,9 +449,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.8.0\n"
+     ]
+    }
+   ],
    "source": [
     "import ipythonblocks\n",
     "print(ipythonblocks.__version__)"
@@ -331,9 +467,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">table.blockgrid {border: none;} .blockgrid tr {border: none;} .blockgrid td {padding: 0px;} #blocks6e0d7032-169a-4b2d-9cd1-78d3b4ee8e88 td {border: 1px solid white;}</style><table id=\"blocks6e0d7032-169a-4b2d-9cd1-78d3b4ee8e88\" class=\"blockgrid\"><tbody><tr><td title=\"Index: [0, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [1, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [2, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [3, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [4, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [5, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [6, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [7, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [8, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [9, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr></tbody></table>"
+      ],
+      "text/plain": [
+       "<ipythonblocks.ipythonblocks.BlockGrid at 0x7f4cf40dd198>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "grid = ipythonblocks.BlockGrid(10, 10, fill=(123, 234, 123))\n",
     "grid"
@@ -353,9 +503,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.1.1\n"
+     ]
+    }
+   ],
    "source": [
     "import palettable\n",
     "print(palettable.__version__)"
@@ -363,9 +521,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.colorbar.Colorbar at 0x7f4cef866e48>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAAD8CAYAAADUv3dIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3XuMXdd1HvDvu3dmyHlzRI5EaUiatENJoZQ4ikZyUiGKLdkRbSl0mraIFDjIq2YLxIlUxAjspID6T4GmLdLUiBuDsBQbsCMjka3UVmXTamKXyMOKSEq2SZESVcoUn+LwNQ9yhvNa/ePO1BNqrz3nHN577jmX38+4sObuOeeu+9pzuNdee9PMICIi+ag0OwARkWuJOl0RkRyp0xURyZE6XRGRHKnTFRHJkTpdEZEcqdMVEcmROl0RkRyp0xURyVFbI066Zs0a27hxYyNOLbLEVKRtZW5RSHZ79uw5Y2aDV3OOaueNZnOXE/2uzZzfaWZbr+bxrlZDOt2NGzdi9+7djTi1yBKvRdpuzi0KyY7kkas9h81dxoq1DyT63amjX7qV5NLOaYeZ7bjaGNJoSKcrIpIbEmTikdIzZjbcyHCWo05XREqNICosT1eW6M8DyUdJ7iO5n+RjjQ5KRCQNspLoVgTL/nkgeTuAjwK4G8A0gG+Q/F9mdqjRwUlrGZ3e6bb1dyQbk2sdGo+uJ5LNDiGxJF3/jwL4jpldMrNZAP8HwD9vbFgiIkkRta4syQ1rSO5ectued7RJBkL2AfiPJFcDmATwIQBvm5qwEPx2ANiwYUM9YxQRiWqpRJqZHSD5hwCeBzAB4LsAZgO/twPADgAYHh7WdhQikgsyVafbdIkiNbMnzOwnzexeAOcAaDxXRAqiNnshya0IEkVB8nozO01yA4BfBPDTjQ1LRCSpVPN0my5p1//lhTHdGQC/ZWbnGxhTCRUlE+3FkTWG2PMKG51+w23LNkMh62ubPvZ83yvNUKinFJ3umlJUpJnZzzQ6EBGRLIhagURCxU+kiYgUW2sOL4iIFBOBSqU8XVl5IhURCVosjigHdbp1kTWhU+9kSvPPNzZ90G07fvFrqc831N3htvX7TXjl/KupH2vLgN9W/wSh1JOGF0REcsJ0Y7rlmL0gIlJkTD68oNkLIiJXS8MLIiJ5IVGpVJsdRWLqdEWk1GrFEbrSlf+vCKWq/uMcnfBnG6zv2ea2vTjybPD+8Rn/imNz35zbdmoy/KUZm/Z3eY3NlIBTobRl4Bb3iPgMhU2Rxyp6yXGrU3GEiEiu1OmKiOSGaYYXNGVMROSqEGDyMmBNGRMRuRq14ojybEypTrfBsu2A6ydmYufLYtcpv5b2jtV+2e63Tq4I3v/Qej/xdWjMT7KdvBRu626bcY/5+9OROmDHS2cPu213rPYfC/CTbJ548i1Gibm0yjR7IVGkJP8dyf0k95F8iuTKRgcmIpIUWUl0K4JloyA5BOB3AAyb2e0AqgAebnRgIiLJcHF3yuVvBZB0eKENQCfJGQBdAE40LiQRkRTKtbLj8qGa2XEA/xXAmwBOAhg1s29e+Xskt5PcTXL3yMhI/SMVEfFUKsluBZBkeGEAwIcBbAJwE4Bukh+58vfMbIeZDZvZ8ODgYP0jFRHxVBLeCiDJ8ML7AbxhZiMAQPIrAP4ZgC80MrBiCmeVs5ePhv3NiUNu29rOebfttdHw23nmsv9p++45fwbA4XF/tsE9N0wH7//P3+91j3lXb2x2QNhB5zkBQG+7/1p4hrrMbYvNhnj3dX7s3W3eOWOfiyyzDeq9q3OLzHggYMnHa0tRHPEmgJ8i2QVgEsD9AHbHDxERyVHyHFnxiyPM7AWSTwPYC2AWwEsAcv3LICISVSnGzIQkEs1eMLPHATze4FhERDIoznSwJFSRJiLlRgBVdbrXlFiyLJZk89aD3dyXLY6+jnBi6a+dkl0AuH6lv8btsUv+x+M/fa8zeH9HxU9UHRzxE3Nzs+H7e/v8L9NNnX7s3U6Sbe9ZP6m4uc9Plp285B/3LzZOBe9/bTSWfPNLrLcM/Lzb5suy63SeO1U3mK50RURyVJ4+V52uiJQc0XqJNBGRQitPn6tOV0RKjoRVC1JuloA6XREpP13pShLjM+FPSqwcdXLW/3TtORs+bmrOP+bIRLvbdnrMbcJKZ0XlI0f92Qs9vX4ck5Ph4y5f9s832ePPhpifC1/5VCJTiw6P+FdL79sYLnsGgM8f6grev67bn11x20CsJDo8s2Go2/9cxGbQHJ34avD+9T23RmIoGc1eEBHJkRJpIiI5IdIML5RiwRsRkWJLPrxQ/AVvREQKjVQZcPFlK3/0SnrHpv0dcE9NxqayhD8oRyZiu+b6b9mRiXDbtJ8DchNYAHD+nL9e7dykkySa9883dcxPHllX+o/ihcjVTcU5X39/5JjIF/cfz/il1F4Yq1deco8Zm/Y/F97OyFsGvN2jgdhnen3PtshxWRSwfFiJNBGRHJWnz1WnKyLlZgCsRLMXkuyRdgvJl5fcxkg+lkdwIiLLIlprC3YzexXATwAAySqA4wCeaXBcIiLJFaM/TSTt8ML9AP6vmR1pRDAiIukRaOG1Fx4G8FQjAslXLMMay8yGeeW8y/mOU+57esqfvfDmRf8tmxgPzxwYGfFnIbRFPgFzE5FSVedDXjl90T2kcnbSbbNIiat/jF/CjLPhuy+M+E94xVB4YXYAmJry32NvRsSuU/75Tl7yX9ufXRueDfPiyLPuMTf3R14LZ1fi+E7Vse9IwRY4T1cc0XSJ/zyQ7ACwDcBfOu3bSe4muXtkZKRe8YmILK/CZLcCSHNN/kEAe83srVCjme0ws2EzGx4cHKxPdCIiSZSo000zvPAIWmJoQURaCgErRn+aSKJOl2QXgA8A+DeNDUdEJINWS6SZ2SUAqxscS478ZFls9949Z5wtayOjNH/3lp8gWlENJ75ia9yOOskyABgdDSfM7C2/HHV2yntOQPWin+yh08YZfw1ZRB6Ll/w21zn/8sa6wq/h/ICzEDCA6Tf82OfXdrttHe3h9/8s/c/F+LT/uehxdjL+/nn/63pzv58sjSfMWgCLM3SQhCrSRKT8ynOhq05XRFpAQarNklCnKyLlpi3YRUTyZbrSLTq/omZs+qDb1uskTI5f9CvIbuzyExx/dSS8oWEk34QLF/xE2qyTB+KknxCrnvaTbIgktzjhLNI76z/f2NUIZ/01iT3W5g/ksSMcH89FquJW+Uk26/S/KqPV8HFm/mtR7fdjn45sJOr51H7/fPfccCh4/303PRg5YwHXzPUQQFtzOl2SvwDgQQDXA/i0mX1zuWNKNPwsIhKScIWxhFfDJJ8keZrkvivu30ryVZKvk/wEAJjZX5nZRwH8GoBfSnJ+dboiUn71rUj7HICtS+9YWGHx06hV5m4B8AjJLUt+5d8vtC8fatIoREQKiwlvCZjZLgDnrrj7bgCvm9lhM5sG8CUAH2bNHwL4upntTXL+a3RMV0RaBlPtHJF1C/YhAEeX/HwMwHsA/DaA9wPoJ/kjZvaZ5U6kTldEyi95p5t1C/bQA5iZfQrAp9KcSJ3uFfo6/F1fd50KzxzYfcYv6byUIRN9ccKfoXD5st+G4xPBu6MzFGKluef9TD+99WAjZcCxbP7svDPbIFJKW13hr1eLTqeUOrILL9r9WSjVN8fctvnp8HO+MOPHF8vpHOgKf54+cJP/fhyLzKC5c034a/7K+a/5QURsGYi1NmFmA5HHFuzHAKxf8vM6ACeynEhjuiJScqlmL6xZXPd74bY94YO8CGAzyU0La4s/DOCrWaLVla6IlF8dhxdIPgXgvah10McAPG5mT5D8GICdAKoAnjSz/VlCVacrIuVW5zJgM3vEuf85AM9d7fnV6YpI6bVcGTDJVQA+C+B2AAbgN8zsHxoZ2NXzyxhfOf+q23Zx1n/zbu4P3/+9c/76t0ciG0m+dd65/0RkjdvDF9w2eiW4sXVxY4m02MaUc+Hk0eRlZ0fIZczNhRNpHR19/jGx8ubL4fek2h5JvsWulub8BCZXht/jyrx/zFhHj9t2tjecapmMLFX809c7ZdkA/vKN8PnefZ3/fO8afMh/sIjR6Z3B+/s7Hsh0vkTSJdKyThmrm6RXuv8dwDfM7F8uDCKHFw0QEcldqmqzrFPG6mbZTpdkH4B7UastxkI1hv9nVUQkbyVa2jHJlLF3AhgB8GckXyL5WZL+3iUiInlKWgJckH45SafbBuAnAfypmd0B4CKAT1z5SyS3L859GxkZqXOYIiJhhloZcJIbss/TrZskY7rHABwzsxcWfn4agU53YTB6BwAMDw9HyqZEROos+eyF4o/pmtkpkkdJ3mJmrwK4H8ArjQ+tcWIzFMZn/LbD4+ln2F3X4Ze+7ht1HmvGP8ZW+OWelbcuBu93FxwHwHG/bX7GX1h8ejb8WDOzfqnqnFPqC/glwjNz/vnanMXDa23hcu7Oil+yzdEpt816Isc5r6H1+sdY5LLk4sVw42uj/vk6q/5re9tAeJbHzf3+rJs4f2ZQQ2cpePIpA66bpL3IbwP44sLMhcMAfr1xIYmIJEcAlRItaJCo0zWzlwE09ZJcRMRTotoIVaSJSMkl34kHKFFxhIhIQRFspURaMcR2Jk2vu83PYtw16K8Hun//D1I/1v4R/yWedUpp6azPCgCV0UhdilOqykhibnYyvAYvAMxGkmKXZ8aD909NO7XNiK+nW6mEX6fYMTHz8+Hy5raqXwbcZn5iLra2sJcV46ifiJxb609199ZMPnA229e10/m8j037r+2dazKtWoj1Pfmvp9uSY7oiIoVFILLWfeGo0xWR0lMiTUQkJ3VeTrfh1OmKSOlp9oKISI5SdLqavXD10mdLe9sPum1HJ/y2zrZwaen+C3555oULkZkDU+G2irfTLgBejJT0eguSRxYqn5v3H8uboQAAs3PhHYZjsw1iZcBeW+x8sZ2CvVkK05Hn5M2gAIBqpGzXIrsIe3jBn9lQ6Q/H7pUHA8DUqvT/vh7q9mfJrO+51W0bnX4jctZ0M43uvPO2O1MdEEKg0oJlwCIihUQokSYikp90FWlNp05XREpPna6ISI40Zazu0ifLjk5kK2M8NeknZw6Nhl+utZ1+QuLNtkipjPdJiZQBm7PzLADwjFOqGtnJNmbesiXgPPGS3nCMlYq/5mvsfPNOYi4WN2MbqXg7LQOgk/hkp59gi+3CfHEi/FqsGvB7lk29/vN693X1XU+3v2NTpDXdd3XPnv17MgWxRMoxXU0ZExG5KulmL5RjyhjJHwAYBzAHYLbZQYuILNWqY7rvM7MzDYtERCSjVu10RUQKp2zzdJMuiGYAvklyTzO2LBYRcbGWk05yK4KkV7r3mNkJktcDeJ7kQTPbtfQXFjrj7QCwYcOGOoeZn28cC5f6AsA6p2wyVgZcjbzC1bbwpyA6Q+GyP7MhiwojuwvTj8M7bh5+Vr7eYmXFXuzV2GwIRGZXzERe93lndkjk8iv2Hledt2RVpNT3wrR//fStk+HPZ3ebX4rc73+ko2XA/R35L2IOAJX0ldhNk+hK18xOLPz/aQDPALg78Ds7zGzYzIYHBwfrG6WIiGNxeCHJrQiW7XRJdpPsXfxvAD8HYF+jAxMRSYQAyUS3IkgyvHADgGcWAm4D8Odm9o2GRiUikkJB+tNElu10zewwgHfnEIuISCaqSMMU/HU16z3QXt+dgn/nNj+Z8h/2hpMws+a/4yv9DWaxYkX4uKnI7r1RXnJmIpJwiqwhG2vzVCt+BiZatuuUHMfOF42j6idEPdEy4NiauU6pt/VGYo+Uh7c5D7W2y0/mdUUW/I1UI7ti60rH1tptFi1iLiKSEzL6N6xw1OmKSKnVNqbMtqhTM6jTFZHSK0rhQxLqdEWk9Eo0utCMTjefBNv6nm1u2+j0Trdtzxm/omp4TfifMOMz/lveFRlsGjkdPl+sWmm+308QVSaddV0jy97FkkexarVqNZIhdMTW560yfcKsva079TGxxFyl3X9trSuy9qyF38fYmrmxzUIrlXAcp6f892plJJH24856ujHjM7FLxyzf1fD3vh4bU2p4QUQkZxpeEBHJCQk4y5gUkjpdESk9anhBRCQftTHdZkeRnDpdESk9zV7AStS/3NfjPY5fHtzf8YDbtrnP30X48Li3Rqv/T5vzlyOzAypOWWd7xo+QU6pqHZE1c2f9jH3HfG/qEGbn/DVaO9r983klwqT/WsTa2qudwfvb2sL3LwTht0VmocyvCs/kmI+VAUdmQ3R2pb9s+8BNU27bjZHyYc9Qd2w2SZbS+/D3tD67AZtmL4iI5ClFIq1VF7wREckH023FowVvRESuloYXRERy0rKzF0hWAewGcNzMHmpcSGmFB/Vjm+cBsbb0Rqb8RFVvu/8XuLsnnJy5fMo/Zn61nwiiVwbcG1lbdtZ/rPa5Hv84R1tbl/9Qs5fcNi+RVq36CZ1YCfOKjv7wMV2RUt9IwhGRUmp4x0XKuVes9hNp/f3hx4qtmRuztjP82sY+m9k1aWPKpjxqNmmudB8FcABAX4NiERHJpEzDC4n+QJBcB+BBAJ9tbDgiIuksLmKe5FYEScP4YwC/B8Ddb4XkdpK7Se4eGRmpS3AiIsshah1ZklsRJNmC/SEAp80sOonZzHaY2bCZDQ8ODtYtQBGR5VRoiW5FkGRM9x4A20h+CLVSsz6SXzCzjzQ2NBGRZFpq9oKZfRLAJwGA5HsBfLxYHW44W9rfkS2Levzi19y2NSvCoyvvW+uXYL425r/EU3PhzLy9y58BcP51fwaAt42s9UVKOiOlr5EqW7TDmdkw7+/4GyvbrVYii4R7x8QWUl/pvBaxmRyR2Qvz1/mPZc5jYa2/yLq3EzTgvyW/8A7/ve9u89/HU5Ph133LwGb3mDJZHF4oC83TFZHSa6kr3aXM7NsAvt2QSEREMiDji04Vja50RaT0NLwgIpITLe1Ycl7SAQDuXBMusz160U/AXL/SX8t0ej58volJP6k0dr2f0JmfSb9uavUHo26brfCfF3vDj8XRyHq6iCSxvAQcIwmnvlhJr/M+OmsOA4BF1r+dXxV5LCeOrsi6uLG23o70HchQt//e3zXoVe1nWRcXaFapb0zLjumKiBSROl0RkZwQQHuJhhfKNP4sIvI2i4uYJ7nV/7H5TpJPkHw66THqdEWk9OrZ6ZJ8kuRpkvuuuH8ryVdJvk7yEwBgZofN7DdTxZrml0VEioaoLXec5JbQ5wBs/SePUVtP/NMAPghgC4BHSG7JEm/LjumOTu902/o7Nrlt993kl0a+OBLO9t42EJ6FAABj0/7ftR8bmA3ef/C8P3uht8f/5Jx3FjhvWxnZyfZSOAYA4Jg/EwEd/nEei+xyzDlnTG7eH6uLLTpuA84sj2k/yz+33l8q2i31BdA9GJ71sP4m//lu6vU/M+9y2k5e8s/3rzb5n5mjE+Edrvs6/BkZsR2zi6ieQwdmtovkxivuvhvA62Z2GABIfgnAhwG8kvb8utIVkVKrbdeTeJWxNYtL0C7ctid8mCEAR5f8fAzAEMnVJD8D4A6Sn0xyopa90hWRawMJtDd+N+DQI5iZnQXwb9OcSJ2uiJReDvN0jwFYv+TndQBOZDmROl0RKb0cyoBfBLCZ5CYAxwE8DOCXs5yoZTvdWLIsXsbol0beNRg+7pXzr7rHeDuxAsCzR8OJjHtv9Nfn3QW/DNhbo3VkxI9hbmN411wAqJyccNu8VHDlhH+MRXbHZSTB5Z4vUrZrnek/2tbtJ6NW9vmJtJ7u8GuxqsN/3e9aM+22ees2e2XoAHD8YqSs2Hla8e9IVt73p3Glw4uzFxJaQ3L3kp93mNmOf3I+8ikA71343WMAHjezJ0h+DMBOAFUAT5rZ/izxtmynKyLXjhTDC8uO6ZrZI879zwF4Ll1kb7dsp0tyJYBdAFYs/P7TZvb41T6wiEg9LO4GXBZJrnQvA7jPzCZItgP4W5JfN7PvNDg2EZFl1YYXEo/pLju80GhJ9kgzAIsDde0Lt/KsLiEiLS/FhW7WKWN1kyhWklWSLwM4DeB5M3uhsWGJiCRTK45ozoI3WSRKpJnZHICfILkKwDMkbzezKxeD2A5gOwBs2LCh7oGml99Cy0Pdfhb9tVE/4+w5PeVnym+NlBzvmw2nqd8TqRB/6fXIJ/GdvW7T5cvhf+zMOqXIAMBxP2PvfiO88mDEdzn2Sp+rkcuMzk7/tejr9w+8risc48/c4M9COXfZf6wHhsLv8Z4z/uyK2MyG9T23Oi3ZZvHEj2vOAudF6VCTSDX8bGYXUNuYcmugbYeZDZvZ8ODgYJ3CExGJIw3VhLciWLbTJTm4cIULkp0A3g/gYKMDExFJgqjNXkhyQ/a1F+omyfDCjQA+v7C0WQXAX5jZs40NS0QkuXrO0220JLMXvgfgjhxiERFJLWVFWtOpIu1tsiYXwrzSYQBY2xkepRmf8dex/esT/hqo67rCa9zGEnPXrY6U0po/BjY+Hr6/o8P/SE10+aNZbc4yUXOzfgxd3elnxEc2F47u0Luuzy9THnR2fJ6MVDYPdfklwt6O1LFkWWxt3GzJreLt+OtiLmsv1I06XREpvRIVpKnTFZFyW5ynm1DxK9JERIqMANoriYcXip9IExEpujIVR6jTFZFSY4FKfJNo4U43axljTPi4/o5sMx688szYouixnYf/7q3wTITrnew6ANy7zp8p8Y9n/Ix4X4aFu88M+LMovOMmZiIzL1b4z+vSbDi1cqMzwwMAuqr+P1F/fsOk23Z4PPw1+te3+IuEx97j3vZwHH45LzA6/Ybb5mvEd6Q5lEgTEclRbCpg0ajTFZFS0+wFEZGclWk9XXW6IlJ6VEVaERQ/EXB0IlwGvGXAT5j0tvsLvJ28FE4s3djlJ5zGpv1rhF/dfMlt+/yhruD9HZFk1ECkHPn2VeEEoZekAoDxGT/2d3SH1+7tafcTfb+22U+Wxday9XbvjYmtwdzf8UDq88WTuZ7if0eSKtGQbit3uiJyLSCUSBMRyVWJ+lx1uiJScizX0o5Jdo5YT/JbJA+Q3E/y0TwCExFJYnF4IckNJdk5YhbA75rZXpK9APaQfN7MXmlwbC3CT1as70l/zPiMX8n00Ibwn/v+js3uMX9z4pDbFrO5P1zZdWTCT5bde4Nf/Xbucvjvf6zqbHhNZKNLxx2r/Yq+8Rn/cmmo24/DWzPZS5QCwPqebW7b0YmvOsf4CdZWSoplkeJCt+lTxpa90jWzk2a2d+G/xwEcADDU6MBERJJiwlsRpBrTJbkRta17XmhEMCIiWZRpwZvEhRwkewB8GcBjZjYWaN++OE4yMjJSzxhFRFxJr3KL0i8n6nRJtqPW4X7RzL4S+h0z22Fmw2Y2PDg4WM8YRUSiKrREtyJYdniBJAE8AeCAmf1R40MSEUnhhzMTSiHJmO49AH4FwPdJvrxw3++b2XONC+takU/G+cURf93UtZ3+X/8tA7e4bUPd4fVb+zs2uMfE1nwdm54K3n9ozJ8NEeOtSXtx1v92xnZujsXutcVnG/hiMxvk7YgWW0/XzP4WxRkOERF5m1a70hURKbQUfa7W0xURuVoppow1vThCna6IlFrKnSOaTp1uU3kJLj+hE0tueWIJovjmhL6x6XBJb7+/TGwm9930YKQ1v40Vs61XK3kpUZ+rTldEys60c4SISJ50pSsikhO2YHGEiEihZSuhaQ51uiJSerrSlYTqvYOrl83PNkMhvgC71+Y/VmyX2/6OesdedPnNvGh9RVpDbHnqdEWk1GpdrjpdEZHckOVZ8kadroi0AF3piojkhGDyxR214I3UU70TMFmSWFljSJ+Yi61x65cjZy2Jrvdrq2RZPaUYXmj6gjfLRkrySZKnSe7LIyARkfTKs0takj8PnwOwtcFxiIhkwhT/K4IkO0fsWth6XUSkkIrSoSahMV0RKT2yPIXAdZvcRnI7yd0kd4+MjNTrtCIiy0g6nluMq+G6XekuTLvYAQDDw8PlWdxSIoqQYfdjyLawuMpvW5GGF0REclWeirQkU8aeAvAPAG4heYzkbzY+LBGR5Fpt9sIjeQQiIpIFSbBEaztqeEFESo8lWsZcna5cY5Qsa0260hURyYmGF0REcqZOV0QkNymWdmw6dboi0gJ0pSsikguCqGi7HmkNKpmVslCnKyKSm2ZVm5HsBvA/AEwD+LaZfXG5Y8rz50FEJKi+q4x5u+WQ3EryVZKvk/zEwt2/COBpM/sogG1Jzq9OV0RKb7EUeLlbQp/DFbvlsLZg76cBfBDAFgCPkNwCYB2Aowu/Npfk5Op0RaT0iGqiWxJmtgvAuSvuvhvA62Z22MymAXwJwIcBHEOt4wUS9qcNGdPds2fPGZJHGnHuJdYAONPgxyiKa+W5XivPE9BzXfSOqz35nj37d5K3rEn46yszbsE+hB9e0QK1zvY9AD4F4E9IPgjga0kCaEina2aDjTjvUiR3N3sr5bxcK8/1WnmegJ5rPZlZHhvnhsYmzMwuAvj1NCfS8IKIyPKOAVi/5Od1AE5kOZE6XRGR5b0IYDPJTSQ7ADwM4KtZTlTmTjfJOEyruFae67XyPAE918IK7ZZjZrMAPgZgJ4ADAP7CzPZnOr+Z9pAUEclLma90RURKp/SdLsmPkzSSSaeMlA7J/0LyIMnvkXyG5Kpmx1RvTrVPyyG5nuS3SB4guZ/ko82OqdFIVkm+RPLZZsdSBKXudEmuB/ABAG82O5YGex7A7Wb246itQvPJJsdTV5Fqn1Y0C+B3zexHAfwUgN9q4ee66FHUxkEFJe90Afw3AL8HoKUHps3smwsD+QDwHfywAqZVeNU+LcfMTprZ3oX/HketMxpqblSNQ3IdgAcBfLbZsRRFaTtdktsAHDez7zY7lpz9BoCvNzuIOgtV+7RsR7SI5EYAdwB4obmRNNQfo3ZhNN/sQIqi0Es7kvzfANYGmv4AwO8D+Ll8I2qc2HM1s/+58Dt/gNo/T5ddPq5kgtU+uUeRI5I9AL4M4DEzG2t2PI1A8iEAp81sD8n3Njueoih0p2tm7w/dT/LHAGwC8N2FlYPWAdhL8m4zO5VjiHXjPddFJH8VwEMA7rfWm+dXt2qfMiC78MW4AAAAyklEQVTZjlqH+0Uz+0qz42mgewBsI/khACsB9JH8gpl9pMlxNVVLzNMl+QMAw2bWkguIkNwK4I8A/KyZjTQ7nnoj2YZagvB+AMdRq/755ayTz4uMtauEzwM4Z2aPNTuevCxc6X7czB5qdizNVtox3WvMnwDoBfA8yZdJfqbZAdVTPat9SuAeAL8C4L6F9/LlhStBuUa0xJWuiEhZ6EpXRCRH6nRFRHKkTldEJEfqdEVEcqROV0QkR+p0RURypE5XRCRH6nRFRHL0/wAmEytLYX+WGwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -395,9 +574,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.1.0\n"
+     ]
+    }
+   ],
    "source": [
     "import altair as alt\n",
     "print(alt.__version__)"
@@ -405,9 +592,4519 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v2+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v2.4.3.json",
+       "config": {
+        "view": {
+         "height": 300,
+         "width": 400
+        }
+       },
+       "data": {
+        "values": [
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 307,
+          "Horsepower": 130,
+          "Miles_per_Gallon": 18,
+          "Name": "chevrolet chevelle malibu",
+          "Origin": "USA",
+          "Weight_in_lbs": 3504,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 11.5,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 165,
+          "Miles_per_Gallon": 15,
+          "Name": "buick skylark 320",
+          "Origin": "USA",
+          "Weight_in_lbs": 3693,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 11,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 18,
+          "Name": "plymouth satellite",
+          "Origin": "USA",
+          "Weight_in_lbs": 3436,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 304,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 16,
+          "Name": "amc rebel sst",
+          "Origin": "USA",
+          "Weight_in_lbs": 3433,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 10.5,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 140,
+          "Miles_per_Gallon": 17,
+          "Name": "ford torino",
+          "Origin": "USA",
+          "Weight_in_lbs": 3449,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 10,
+          "Cylinders": 8,
+          "Displacement": 429,
+          "Horsepower": 198,
+          "Miles_per_Gallon": 15,
+          "Name": "ford galaxie 500",
+          "Origin": "USA",
+          "Weight_in_lbs": 4341,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 9,
+          "Cylinders": 8,
+          "Displacement": 454,
+          "Horsepower": 220,
+          "Miles_per_Gallon": 14,
+          "Name": "chevrolet impala",
+          "Origin": "USA",
+          "Weight_in_lbs": 4354,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 8.5,
+          "Cylinders": 8,
+          "Displacement": 440,
+          "Horsepower": 215,
+          "Miles_per_Gallon": 14,
+          "Name": "plymouth fury iii",
+          "Origin": "USA",
+          "Weight_in_lbs": 4312,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 10,
+          "Cylinders": 8,
+          "Displacement": 455,
+          "Horsepower": 225,
+          "Miles_per_Gallon": 14,
+          "Name": "pontiac catalina",
+          "Origin": "USA",
+          "Weight_in_lbs": 4425,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 8.5,
+          "Cylinders": 8,
+          "Displacement": 390,
+          "Horsepower": 190,
+          "Miles_per_Gallon": 15,
+          "Name": "amc ambassador dpl",
+          "Origin": "USA",
+          "Weight_in_lbs": 3850,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 17.5,
+          "Cylinders": 4,
+          "Displacement": 133,
+          "Horsepower": 115,
+          "Miles_per_Gallon": null,
+          "Name": "citroen ds-21 pallas",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3090,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 11.5,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 165,
+          "Miles_per_Gallon": null,
+          "Name": "chevrolet chevelle concours (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4142,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 11,
+          "Cylinders": 8,
+          "Displacement": 351,
+          "Horsepower": 153,
+          "Miles_per_Gallon": null,
+          "Name": "ford torino (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4034,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 10.5,
+          "Cylinders": 8,
+          "Displacement": 383,
+          "Horsepower": 175,
+          "Miles_per_Gallon": null,
+          "Name": "plymouth satellite (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4166,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 11,
+          "Cylinders": 8,
+          "Displacement": 360,
+          "Horsepower": 175,
+          "Miles_per_Gallon": null,
+          "Name": "amc rebel sst (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 3850,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 10,
+          "Cylinders": 8,
+          "Displacement": 383,
+          "Horsepower": 170,
+          "Miles_per_Gallon": 15,
+          "Name": "dodge challenger se",
+          "Origin": "USA",
+          "Weight_in_lbs": 3563,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 8,
+          "Cylinders": 8,
+          "Displacement": 340,
+          "Horsepower": 160,
+          "Miles_per_Gallon": 14,
+          "Name": "plymouth 'cuda 340",
+          "Origin": "USA",
+          "Weight_in_lbs": 3609,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 8,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 140,
+          "Miles_per_Gallon": null,
+          "Name": "ford mustang boss 302",
+          "Origin": "USA",
+          "Weight_in_lbs": 3353,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 9.5,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 15,
+          "Name": "chevrolet monte carlo",
+          "Origin": "USA",
+          "Weight_in_lbs": 3761,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 10,
+          "Cylinders": 8,
+          "Displacement": 455,
+          "Horsepower": 225,
+          "Miles_per_Gallon": 14,
+          "Name": "buick estate wagon (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 3086,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 4,
+          "Displacement": 113,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 24,
+          "Name": "toyota corona mark ii",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2372,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 6,
+          "Displacement": 198,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 22,
+          "Name": "plymouth duster",
+          "Origin": "USA",
+          "Weight_in_lbs": 2833,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 6,
+          "Displacement": 199,
+          "Horsepower": 97,
+          "Miles_per_Gallon": 18,
+          "Name": "amc hornet",
+          "Origin": "USA",
+          "Weight_in_lbs": 2774,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 6,
+          "Displacement": 200,
+          "Horsepower": 85,
+          "Miles_per_Gallon": 21,
+          "Name": "ford maverick",
+          "Origin": "USA",
+          "Weight_in_lbs": 2587,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 27,
+          "Name": "datsun pl510",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2130,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 20.5,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 46,
+          "Miles_per_Gallon": 26,
+          "Name": "volkswagen 1131 deluxe sedan",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1835,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 17.5,
+          "Cylinders": 4,
+          "Displacement": 110,
+          "Horsepower": 87,
+          "Miles_per_Gallon": 25,
+          "Name": "peugeot 504",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2672,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 107,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 24,
+          "Name": "audi 100 ls",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2430,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 17.5,
+          "Cylinders": 4,
+          "Displacement": 104,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 25,
+          "Name": "saab 99e",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2375,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 12.5,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 113,
+          "Miles_per_Gallon": 26,
+          "Name": "bmw 2002",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2234,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 6,
+          "Displacement": 199,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 21,
+          "Name": "amc gremlin",
+          "Origin": "USA",
+          "Weight_in_lbs": 2648,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 8,
+          "Displacement": 360,
+          "Horsepower": 215,
+          "Miles_per_Gallon": 10,
+          "Name": "ford f250",
+          "Origin": "USA",
+          "Weight_in_lbs": 4615,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 8,
+          "Displacement": 307,
+          "Horsepower": 200,
+          "Miles_per_Gallon": 10,
+          "Name": "chevy c20",
+          "Origin": "USA",
+          "Weight_in_lbs": 4376,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 210,
+          "Miles_per_Gallon": 11,
+          "Name": "dodge d200",
+          "Origin": "USA",
+          "Weight_in_lbs": 4382,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 18.5,
+          "Cylinders": 8,
+          "Displacement": 304,
+          "Horsepower": 193,
+          "Miles_per_Gallon": 9,
+          "Name": "hi 1200d",
+          "Origin": "USA",
+          "Weight_in_lbs": 4732,
+          "Year": "1970-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 27,
+          "Name": "datsun pl510",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2130,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 28,
+          "Name": "chevrolet vega 2300",
+          "Origin": "USA",
+          "Weight_in_lbs": 2264,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 4,
+          "Displacement": 113,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 25,
+          "Name": "toyota corona",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2228,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": null,
+          "Miles_per_Gallon": 25,
+          "Name": "ford pinto",
+          "Origin": "USA",
+          "Weight_in_lbs": 2046,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 20,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 48,
+          "Miles_per_Gallon": null,
+          "Name": "volkswagen super beetle 117",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1978,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 19,
+          "Name": "amc gremlin",
+          "Origin": "USA",
+          "Weight_in_lbs": 2634,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 16,
+          "Name": "plymouth satellite custom",
+          "Origin": "USA",
+          "Weight_in_lbs": 3439,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 17,
+          "Name": "chevrolet chevelle malibu",
+          "Origin": "USA",
+          "Weight_in_lbs": 3329,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 19,
+          "Name": "ford torino 500",
+          "Origin": "USA",
+          "Weight_in_lbs": 3302,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 18,
+          "Name": "amc matador",
+          "Origin": "USA",
+          "Weight_in_lbs": 3288,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 165,
+          "Miles_per_Gallon": 14,
+          "Name": "chevrolet impala",
+          "Origin": "USA",
+          "Weight_in_lbs": 4209,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 11.5,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 175,
+          "Miles_per_Gallon": 14,
+          "Name": "pontiac catalina brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 4464,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 8,
+          "Displacement": 351,
+          "Horsepower": 153,
+          "Miles_per_Gallon": 14,
+          "Name": "ford galaxie 500",
+          "Origin": "USA",
+          "Weight_in_lbs": 4154,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 14,
+          "Name": "plymouth fury iii",
+          "Origin": "USA",
+          "Weight_in_lbs": 4096,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 11.5,
+          "Cylinders": 8,
+          "Displacement": 383,
+          "Horsepower": 180,
+          "Miles_per_Gallon": 12,
+          "Name": "dodge monaco (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4955,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 170,
+          "Miles_per_Gallon": 13,
+          "Name": "ford country squire (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4746,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 175,
+          "Miles_per_Gallon": 13,
+          "Name": "pontiac safari (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 5140,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 6,
+          "Displacement": 258,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 18,
+          "Name": "amc hornet sportabout (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 2962,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 72,
+          "Miles_per_Gallon": 22,
+          "Name": "chevrolet vega (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 2408,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 19,
+          "Name": "pontiac firebird",
+          "Origin": "USA",
+          "Weight_in_lbs": 3282,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 18,
+          "Name": "ford mustang",
+          "Origin": "USA",
+          "Weight_in_lbs": 3139,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 4,
+          "Displacement": 122,
+          "Horsepower": 86,
+          "Miles_per_Gallon": 23,
+          "Name": "mercury capri 2000",
+          "Origin": "USA",
+          "Weight_in_lbs": 2220,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 4,
+          "Displacement": 116,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 28,
+          "Name": "opel 1900",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2123,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 19.5,
+          "Cylinders": 4,
+          "Displacement": 79,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 30,
+          "Name": "peugeot 304",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2074,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 88,
+          "Horsepower": 76,
+          "Miles_per_Gallon": 30,
+          "Name": "fiat 124b",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2065,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 4,
+          "Displacement": 71,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 31,
+          "Name": "toyota corolla 1200",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1773,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 18,
+          "Cylinders": 4,
+          "Displacement": 72,
+          "Horsepower": 69,
+          "Miles_per_Gallon": 35,
+          "Name": "datsun 1200",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1613,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 60,
+          "Miles_per_Gallon": 27,
+          "Name": "volkswagen model 111",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1834,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 20.5,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 26,
+          "Name": "plymouth cricket",
+          "Origin": "USA",
+          "Weight_in_lbs": 1955,
+          "Year": "1971-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 113,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 24,
+          "Name": "toyota corona hardtop",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2278,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 4,
+          "Displacement": 97.5,
+          "Horsepower": 80,
+          "Miles_per_Gallon": 25,
+          "Name": "dodge colt hardtop",
+          "Origin": "USA",
+          "Weight_in_lbs": 2126,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 23.5,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 54,
+          "Miles_per_Gallon": 23,
+          "Name": "volkswagen type 3",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2254,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 19.5,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 20,
+          "Name": "chevrolet vega",
+          "Origin": "USA",
+          "Weight_in_lbs": 2408,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 4,
+          "Displacement": 122,
+          "Horsepower": 86,
+          "Miles_per_Gallon": 21,
+          "Name": "ford pinto runabout",
+          "Origin": "USA",
+          "Weight_in_lbs": 2226,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 165,
+          "Miles_per_Gallon": 13,
+          "Name": "chevrolet impala",
+          "Origin": "USA",
+          "Weight_in_lbs": 4274,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 175,
+          "Miles_per_Gallon": 14,
+          "Name": "pontiac catalina",
+          "Origin": "USA",
+          "Weight_in_lbs": 4385,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 15,
+          "Name": "plymouth fury iii",
+          "Origin": "USA",
+          "Weight_in_lbs": 4135,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 351,
+          "Horsepower": 153,
+          "Miles_per_Gallon": 14,
+          "Name": "ford galaxie 500",
+          "Origin": "USA",
+          "Weight_in_lbs": 4129,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 11.5,
+          "Cylinders": 8,
+          "Displacement": 304,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 17,
+          "Name": "amc ambassador sst",
+          "Origin": "USA",
+          "Weight_in_lbs": 3672,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 11,
+          "Cylinders": 8,
+          "Displacement": 429,
+          "Horsepower": 208,
+          "Miles_per_Gallon": 11,
+          "Name": "mercury marquis",
+          "Origin": "USA",
+          "Weight_in_lbs": 4633,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 155,
+          "Miles_per_Gallon": 13,
+          "Name": "buick lesabre custom",
+          "Origin": "USA",
+          "Weight_in_lbs": 4502,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 160,
+          "Miles_per_Gallon": 12,
+          "Name": "oldsmobile delta 88 royale",
+          "Origin": "USA",
+          "Weight_in_lbs": 4456,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 12.5,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 190,
+          "Miles_per_Gallon": 13,
+          "Name": "chrysler newport royal",
+          "Origin": "USA",
+          "Weight_in_lbs": 4422,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 3,
+          "Displacement": 70,
+          "Horsepower": 97,
+          "Miles_per_Gallon": 19,
+          "Name": "mazda rx2 coupe",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2330,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 12.5,
+          "Cylinders": 8,
+          "Displacement": 304,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 15,
+          "Name": "amc matador (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 3892,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 8,
+          "Displacement": 307,
+          "Horsepower": 130,
+          "Miles_per_Gallon": 13,
+          "Name": "chevrolet chevelle concours (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4098,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 140,
+          "Miles_per_Gallon": 13,
+          "Name": "ford gran torino (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4294,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 14,
+          "Name": "plymouth satellite custom (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4077,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 112,
+          "Miles_per_Gallon": 18,
+          "Name": "volvo 145e (sw)",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2933,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 18,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 76,
+          "Miles_per_Gallon": 22,
+          "Name": "volkswagen 411 (sw)",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2511,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 19.5,
+          "Cylinders": 4,
+          "Displacement": 120,
+          "Horsepower": 87,
+          "Miles_per_Gallon": 21,
+          "Name": "peugeot 504 (sw)",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2979,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 18,
+          "Cylinders": 4,
+          "Displacement": 96,
+          "Horsepower": 69,
+          "Miles_per_Gallon": 26,
+          "Name": "renault 12 (sw)",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2189,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 4,
+          "Displacement": 122,
+          "Horsepower": 86,
+          "Miles_per_Gallon": 22,
+          "Name": "ford pinto (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 2395,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 92,
+          "Miles_per_Gallon": 28,
+          "Name": "datsun 510 (sw)",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2288,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 120,
+          "Horsepower": 97,
+          "Miles_per_Gallon": 23,
+          "Name": "toyouta corona mark ii (sw)",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2506,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 80,
+          "Miles_per_Gallon": 28,
+          "Name": "dodge colt (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 2164,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 27,
+          "Name": "toyota corolla 1600 (sw)",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2100,
+          "Year": "1972-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 175,
+          "Miles_per_Gallon": 13,
+          "Name": "buick century 350",
+          "Origin": "USA",
+          "Weight_in_lbs": 4100,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 11.5,
+          "Cylinders": 8,
+          "Displacement": 304,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 14,
+          "Name": "amc matador",
+          "Origin": "USA",
+          "Weight_in_lbs": 3672,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 145,
+          "Miles_per_Gallon": 13,
+          "Name": "chevrolet malibu",
+          "Origin": "USA",
+          "Weight_in_lbs": 3988,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 137,
+          "Miles_per_Gallon": 14,
+          "Name": "ford gran torino",
+          "Origin": "USA",
+          "Weight_in_lbs": 4042,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 12.5,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 15,
+          "Name": "dodge coronet custom",
+          "Origin": "USA",
+          "Weight_in_lbs": 3777,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 11.5,
+          "Cylinders": 8,
+          "Displacement": 429,
+          "Horsepower": 198,
+          "Miles_per_Gallon": 12,
+          "Name": "mercury marquis brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 4952,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 13,
+          "Name": "chevrolet caprice classic",
+          "Origin": "USA",
+          "Weight_in_lbs": 4464,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 351,
+          "Horsepower": 158,
+          "Miles_per_Gallon": 13,
+          "Name": "ford ltd",
+          "Origin": "USA",
+          "Weight_in_lbs": 4363,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 14,
+          "Name": "plymouth fury gran sedan",
+          "Origin": "USA",
+          "Weight_in_lbs": 4237,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 11,
+          "Cylinders": 8,
+          "Displacement": 440,
+          "Horsepower": 215,
+          "Miles_per_Gallon": 13,
+          "Name": "chrysler new yorker brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 4735,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 11,
+          "Cylinders": 8,
+          "Displacement": 455,
+          "Horsepower": 225,
+          "Miles_per_Gallon": 12,
+          "Name": "buick electra 225 custom",
+          "Origin": "USA",
+          "Weight_in_lbs": 4951,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 11,
+          "Cylinders": 8,
+          "Displacement": 360,
+          "Horsepower": 175,
+          "Miles_per_Gallon": 13,
+          "Name": "amc ambassador brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 3821,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 18,
+          "Name": "plymouth valiant",
+          "Origin": "USA",
+          "Weight_in_lbs": 3121,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 18,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 16,
+          "Name": "chevrolet nova custom",
+          "Origin": "USA",
+          "Weight_in_lbs": 3278,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 18,
+          "Name": "amc hornet",
+          "Origin": "USA",
+          "Weight_in_lbs": 2945,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 18,
+          "Name": "ford maverick",
+          "Origin": "USA",
+          "Weight_in_lbs": 3021,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 6,
+          "Displacement": 198,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 23,
+          "Name": "plymouth duster",
+          "Origin": "USA",
+          "Weight_in_lbs": 2904,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 21,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 46,
+          "Miles_per_Gallon": 26,
+          "Name": "volkswagen super beetle",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1950,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 11,
+          "Name": "chevrolet impala",
+          "Origin": "USA",
+          "Weight_in_lbs": 4997,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 12.5,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 167,
+          "Miles_per_Gallon": 12,
+          "Name": "ford country",
+          "Origin": "USA",
+          "Weight_in_lbs": 4906,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 360,
+          "Horsepower": 170,
+          "Miles_per_Gallon": 13,
+          "Name": "plymouth custom suburb",
+          "Origin": "USA",
+          "Weight_in_lbs": 4654,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 12.5,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 180,
+          "Miles_per_Gallon": 12,
+          "Name": "oldsmobile vista cruiser",
+          "Origin": "USA",
+          "Weight_in_lbs": 4499,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 18,
+          "Name": "amc gremlin",
+          "Origin": "USA",
+          "Weight_in_lbs": 2789,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 20,
+          "Name": "toyota carina",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2279,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 19.5,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 72,
+          "Miles_per_Gallon": 21,
+          "Name": "chevrolet vega",
+          "Origin": "USA",
+          "Weight_in_lbs": 2401,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 4,
+          "Displacement": 108,
+          "Horsepower": 94,
+          "Miles_per_Gallon": 22,
+          "Name": "datsun 610",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2379,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 3,
+          "Displacement": 70,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 18,
+          "Name": "maxda rx3",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2124,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 18.5,
+          "Cylinders": 4,
+          "Displacement": 122,
+          "Horsepower": 85,
+          "Miles_per_Gallon": 19,
+          "Name": "ford pinto",
+          "Origin": "USA",
+          "Weight_in_lbs": 2310,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 6,
+          "Displacement": 155,
+          "Horsepower": 107,
+          "Miles_per_Gallon": 21,
+          "Name": "mercury capri v6",
+          "Origin": "USA",
+          "Weight_in_lbs": 2472,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 26,
+          "Name": "fiat 124 sport coupe",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2265,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 145,
+          "Miles_per_Gallon": 15,
+          "Name": "chevrolet monte carlo s",
+          "Origin": "USA",
+          "Weight_in_lbs": 4082,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 9.5,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 230,
+          "Miles_per_Gallon": 16,
+          "Name": "pontiac grand prix",
+          "Origin": "USA",
+          "Weight_in_lbs": 4278,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 19.5,
+          "Cylinders": 4,
+          "Displacement": 68,
+          "Horsepower": 49,
+          "Miles_per_Gallon": 29,
+          "Name": "fiat 128",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1867,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 116,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 24,
+          "Name": "opel manta",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2158,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 4,
+          "Displacement": 114,
+          "Horsepower": 91,
+          "Miles_per_Gallon": 20,
+          "Name": "audi 100ls",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2582,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 112,
+          "Miles_per_Gallon": 19,
+          "Name": "volvo 144ea",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2868,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 11,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 15,
+          "Name": "dodge dart custom",
+          "Origin": "USA",
+          "Weight_in_lbs": 3399,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 24,
+          "Name": "saab 99le",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2660,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 6,
+          "Displacement": 156,
+          "Horsepower": 122,
+          "Miles_per_Gallon": 20,
+          "Name": "toyota mark ii",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2807,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 11,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 180,
+          "Miles_per_Gallon": 11,
+          "Name": "oldsmobile omega",
+          "Origin": "USA",
+          "Weight_in_lbs": 3664,
+          "Year": "1973-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 6,
+          "Displacement": 198,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 20,
+          "Name": "plymouth duster",
+          "Origin": "USA",
+          "Weight_in_lbs": 3102,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 6,
+          "Displacement": 200,
+          "Horsepower": null,
+          "Miles_per_Gallon": 21,
+          "Name": "ford maverick",
+          "Origin": "USA",
+          "Weight_in_lbs": 2875,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 19,
+          "Name": "amc hornet",
+          "Origin": "USA",
+          "Weight_in_lbs": 2901,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 15,
+          "Name": "chevrolet nova",
+          "Origin": "USA",
+          "Weight_in_lbs": 3336,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 4,
+          "Displacement": 79,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 31,
+          "Name": "datsun b210",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1950,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 4,
+          "Displacement": 122,
+          "Horsepower": 80,
+          "Miles_per_Gallon": 26,
+          "Name": "ford pinto",
+          "Origin": "USA",
+          "Weight_in_lbs": 2451,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 21,
+          "Cylinders": 4,
+          "Displacement": 71,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 32,
+          "Name": "toyota corolla 1200",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1836,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 25,
+          "Name": "chevrolet vega",
+          "Origin": "USA",
+          "Weight_in_lbs": 2542,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 16,
+          "Name": "chevrolet chevelle malibu classic",
+          "Origin": "USA",
+          "Weight_in_lbs": 3781,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 18,
+          "Cylinders": 6,
+          "Displacement": 258,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 16,
+          "Name": "amc matador",
+          "Origin": "USA",
+          "Weight_in_lbs": 3632,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 18,
+          "Name": "plymouth satellite sebring",
+          "Origin": "USA",
+          "Weight_in_lbs": 3613,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 140,
+          "Miles_per_Gallon": 16,
+          "Name": "ford gran torino",
+          "Origin": "USA",
+          "Weight_in_lbs": 4141,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 13,
+          "Name": "buick century luxus (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4699,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 14,
+          "Name": "dodge coronet custom (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4457,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 140,
+          "Miles_per_Gallon": 14,
+          "Name": "ford gran torino (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4638,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 8,
+          "Displacement": 304,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 14,
+          "Name": "amc matador (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4257,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 83,
+          "Miles_per_Gallon": 29,
+          "Name": "audi fox",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2219,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 79,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 26,
+          "Name": "volkswagen dasher",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1963,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 78,
+          "Miles_per_Gallon": 26,
+          "Name": "opel manta",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2300,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 4,
+          "Displacement": 76,
+          "Horsepower": 52,
+          "Miles_per_Gallon": 31,
+          "Name": "toyota corona",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1649,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 4,
+          "Displacement": 83,
+          "Horsepower": 61,
+          "Miles_per_Gallon": 32,
+          "Name": "datsun 710",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2003,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 90,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 28,
+          "Name": "dodge colt",
+          "Origin": "USA",
+          "Weight_in_lbs": 2125,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 90,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 24,
+          "Name": "fiat 128",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2108,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 4,
+          "Displacement": 116,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 26,
+          "Name": "fiat 124 tc",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2246,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 4,
+          "Displacement": 120,
+          "Horsepower": 97,
+          "Miles_per_Gallon": 24,
+          "Name": "honda civic",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2489,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 108,
+          "Horsepower": 93,
+          "Miles_per_Gallon": 26,
+          "Name": "subaru",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2391,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 4,
+          "Displacement": 79,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 31,
+          "Name": "fiat x1.9",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2000,
+          "Year": "1974-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 19,
+          "Name": "plymouth valiant custom",
+          "Origin": "USA",
+          "Weight_in_lbs": 3264,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 18,
+          "Name": "chevrolet nova",
+          "Origin": "USA",
+          "Weight_in_lbs": 3459,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 21,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 72,
+          "Miles_per_Gallon": 15,
+          "Name": "mercury monarch",
+          "Origin": "USA",
+          "Weight_in_lbs": 3432,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 19.5,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 72,
+          "Miles_per_Gallon": 15,
+          "Name": "ford maverick",
+          "Origin": "USA",
+          "Weight_in_lbs": 3158,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 11.5,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 170,
+          "Miles_per_Gallon": 16,
+          "Name": "pontiac catalina",
+          "Origin": "USA",
+          "Weight_in_lbs": 4668,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 145,
+          "Miles_per_Gallon": 15,
+          "Name": "chevrolet bel air",
+          "Origin": "USA",
+          "Weight_in_lbs": 4440,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 16,
+          "Name": "plymouth grand fury",
+          "Origin": "USA",
+          "Weight_in_lbs": 4498,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 8,
+          "Displacement": 351,
+          "Horsepower": 148,
+          "Miles_per_Gallon": 14,
+          "Name": "ford ltd",
+          "Origin": "USA",
+          "Weight_in_lbs": 4657,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 21,
+          "Cylinders": 6,
+          "Displacement": 231,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 17,
+          "Name": "buick century",
+          "Origin": "USA",
+          "Weight_in_lbs": 3907,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 18.5,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 16,
+          "Name": "chevroelt chevelle malibu",
+          "Origin": "USA",
+          "Weight_in_lbs": 3897,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 6,
+          "Displacement": 258,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 15,
+          "Name": "amc matador",
+          "Origin": "USA",
+          "Weight_in_lbs": 3730,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 18,
+          "Name": "plymouth fury",
+          "Origin": "USA",
+          "Weight_in_lbs": 3785,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 6,
+          "Displacement": 231,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 21,
+          "Name": "buick skyhawk",
+          "Origin": "USA",
+          "Weight_in_lbs": 3039,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 8,
+          "Displacement": 262,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 20,
+          "Name": "chevrolet monza 2+2",
+          "Origin": "USA",
+          "Weight_in_lbs": 3221,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 129,
+          "Miles_per_Gallon": 13,
+          "Name": "ford mustang ii",
+          "Origin": "USA",
+          "Weight_in_lbs": 3169,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 29,
+          "Name": "toyota corolla",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2171,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 83,
+          "Miles_per_Gallon": 23,
+          "Name": "ford pinto",
+          "Origin": "USA",
+          "Weight_in_lbs": 2639,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 20,
+          "Name": "amc gremlin",
+          "Origin": "USA",
+          "Weight_in_lbs": 2914,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 18.5,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 78,
+          "Miles_per_Gallon": 23,
+          "Name": "pontiac astro",
+          "Origin": "USA",
+          "Weight_in_lbs": 2592,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 4,
+          "Displacement": 134,
+          "Horsepower": 96,
+          "Miles_per_Gallon": 24,
+          "Name": "toyota corona",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2702,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 4,
+          "Displacement": 90,
+          "Horsepower": 71,
+          "Miles_per_Gallon": 25,
+          "Name": "volkswagen dasher",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2223,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 4,
+          "Displacement": 119,
+          "Horsepower": 97,
+          "Miles_per_Gallon": 24,
+          "Name": "datsun 710",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2545,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 6,
+          "Displacement": 171,
+          "Horsepower": 97,
+          "Miles_per_Gallon": 18,
+          "Name": "ford pinto",
+          "Origin": "USA",
+          "Weight_in_lbs": 2984,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 4,
+          "Displacement": 90,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 29,
+          "Name": "volkswagen rabbit",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1937,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 19,
+          "Name": "amc pacer",
+          "Origin": "USA",
+          "Weight_in_lbs": 3211,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 4,
+          "Displacement": 115,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 23,
+          "Name": "audi 100ls",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2694,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 4,
+          "Displacement": 120,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 23,
+          "Name": "peugeot 504",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2957,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 98,
+          "Miles_per_Gallon": 22,
+          "Name": "volvo 244dl",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2945,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 115,
+          "Miles_per_Gallon": 25,
+          "Name": "saab 99le",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2671,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 17.5,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 53,
+          "Miles_per_Gallon": 33,
+          "Name": "honda civic cvcc",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1795,
+          "Year": "1975-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 107,
+          "Horsepower": 86,
+          "Miles_per_Gallon": 28,
+          "Name": "fiat 131",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2464,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 16.9,
+          "Cylinders": 4,
+          "Displacement": 116,
+          "Horsepower": 81,
+          "Miles_per_Gallon": 25,
+          "Name": "opel 1900",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2220,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 14.9,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 92,
+          "Miles_per_Gallon": 25,
+          "Name": "capri ii",
+          "Origin": "USA",
+          "Weight_in_lbs": 2572,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 17.7,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 79,
+          "Miles_per_Gallon": 26,
+          "Name": "dodge colt",
+          "Origin": "USA",
+          "Weight_in_lbs": 2255,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 15.3,
+          "Cylinders": 4,
+          "Displacement": 101,
+          "Horsepower": 83,
+          "Miles_per_Gallon": 27,
+          "Name": "renault 12tl",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2202,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 305,
+          "Horsepower": 140,
+          "Miles_per_Gallon": 17.5,
+          "Name": "chevrolet chevelle malibu classic",
+          "Origin": "USA",
+          "Weight_in_lbs": 4215,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 16,
+          "Name": "dodge coronet brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 4190,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 13.9,
+          "Cylinders": 8,
+          "Displacement": 304,
+          "Horsepower": 120,
+          "Miles_per_Gallon": 15.5,
+          "Name": "amc matador",
+          "Origin": "USA",
+          "Weight_in_lbs": 3962,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 12.8,
+          "Cylinders": 8,
+          "Displacement": 351,
+          "Horsepower": 152,
+          "Miles_per_Gallon": 14.5,
+          "Name": "ford gran torino",
+          "Origin": "USA",
+          "Weight_in_lbs": 4215,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 15.4,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 22,
+          "Name": "plymouth valiant",
+          "Origin": "USA",
+          "Weight_in_lbs": 3233,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 22,
+          "Name": "chevrolet nova",
+          "Origin": "USA",
+          "Weight_in_lbs": 3353,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 17.6,
+          "Cylinders": 6,
+          "Displacement": 200,
+          "Horsepower": 81,
+          "Miles_per_Gallon": 24,
+          "Name": "ford maverick",
+          "Origin": "USA",
+          "Weight_in_lbs": 3012,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 17.6,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 22.5,
+          "Name": "amc hornet",
+          "Origin": "USA",
+          "Weight_in_lbs": 3085,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 22.2,
+          "Cylinders": 4,
+          "Displacement": 85,
+          "Horsepower": 52,
+          "Miles_per_Gallon": 29,
+          "Name": "chevrolet chevette",
+          "Origin": "USA",
+          "Weight_in_lbs": 2035,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 22.1,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 60,
+          "Miles_per_Gallon": 24.5,
+          "Name": "chevrolet woody",
+          "Origin": "USA",
+          "Weight_in_lbs": 2164,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 14.2,
+          "Cylinders": 4,
+          "Displacement": 90,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 29,
+          "Name": "vw rabbit",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1937,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 17.4,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 53,
+          "Miles_per_Gallon": 33,
+          "Name": "honda civic",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1795,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 17.7,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 20,
+          "Name": "dodge aspen se",
+          "Origin": "USA",
+          "Weight_in_lbs": 3651,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 21,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 78,
+          "Miles_per_Gallon": 18,
+          "Name": "ford granada ghia",
+          "Origin": "USA",
+          "Weight_in_lbs": 3574,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 16.2,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 18.5,
+          "Name": "pontiac ventura sj",
+          "Origin": "USA",
+          "Weight_in_lbs": 3645,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 17.8,
+          "Cylinders": 6,
+          "Displacement": 258,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 17.5,
+          "Name": "amc pacer d/l",
+          "Origin": "USA",
+          "Weight_in_lbs": 3193,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 12.2,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 71,
+          "Miles_per_Gallon": 29.5,
+          "Name": "volkswagen rabbit",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1825,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 4,
+          "Displacement": 85,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 32,
+          "Name": "datsun b-210",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1990,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 16.4,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 28,
+          "Name": "toyota corolla",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2155,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 13.6,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 72,
+          "Miles_per_Gallon": 26.5,
+          "Name": "ford pinto",
+          "Origin": "USA",
+          "Weight_in_lbs": 2565,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 15.7,
+          "Cylinders": 4,
+          "Displacement": 130,
+          "Horsepower": 102,
+          "Miles_per_Gallon": 20,
+          "Name": "volvo 245",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3150,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 13.2,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 13,
+          "Name": "plymouth volare premier v8",
+          "Origin": "USA",
+          "Weight_in_lbs": 3940,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 21.9,
+          "Cylinders": 4,
+          "Displacement": 120,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 19,
+          "Name": "peugeot 504",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3270,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 6,
+          "Displacement": 156,
+          "Horsepower": 108,
+          "Miles_per_Gallon": 19,
+          "Name": "toyota mark ii",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2930,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 16.7,
+          "Cylinders": 6,
+          "Displacement": 168,
+          "Horsepower": 120,
+          "Miles_per_Gallon": 16.5,
+          "Name": "mercedes-benz 280s",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3820,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 12.1,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 180,
+          "Miles_per_Gallon": 16.5,
+          "Name": "cadillac seville",
+          "Origin": "USA",
+          "Weight_in_lbs": 4380,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 12,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 145,
+          "Miles_per_Gallon": 13,
+          "Name": "chevy c10",
+          "Origin": "USA",
+          "Weight_in_lbs": 4055,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 130,
+          "Miles_per_Gallon": 13,
+          "Name": "ford f108",
+          "Origin": "USA",
+          "Weight_in_lbs": 3870,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 13,
+          "Name": "dodge d100",
+          "Origin": "USA",
+          "Weight_in_lbs": 3755,
+          "Year": "1976-01-01"
+         },
+         {
+          "Acceleration": 18.5,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 68,
+          "Miles_per_Gallon": 31.5,
+          "Name": "honda Accelerationord cvcc",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2045,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 14.8,
+          "Cylinders": 4,
+          "Displacement": 111,
+          "Horsepower": 80,
+          "Miles_per_Gallon": 30,
+          "Name": "buick opel isuzu deluxe",
+          "Origin": "USA",
+          "Weight_in_lbs": 2155,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 18.6,
+          "Cylinders": 4,
+          "Displacement": 79,
+          "Horsepower": 58,
+          "Miles_per_Gallon": 36,
+          "Name": "renault 5 gtl",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1825,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 122,
+          "Horsepower": 96,
+          "Miles_per_Gallon": 25.5,
+          "Name": "plymouth arrow gs",
+          "Origin": "USA",
+          "Weight_in_lbs": 2300,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 16.8,
+          "Cylinders": 4,
+          "Displacement": 85,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 33.5,
+          "Name": "datsun f-10 hatchback",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1945,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 12.5,
+          "Cylinders": 8,
+          "Displacement": 305,
+          "Horsepower": 145,
+          "Miles_per_Gallon": 17.5,
+          "Name": "chevrolet caprice classic",
+          "Origin": "USA",
+          "Weight_in_lbs": 3880,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 8,
+          "Displacement": 260,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 17,
+          "Name": "oldsmobile cutlass supreme",
+          "Origin": "USA",
+          "Weight_in_lbs": 4060,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 13.7,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 145,
+          "Miles_per_Gallon": 15.5,
+          "Name": "dodge monaco brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 4140,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 14.9,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 130,
+          "Miles_per_Gallon": 15,
+          "Name": "mercury cougar brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 4295,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 16.4,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 17.5,
+          "Name": "chevrolet concours",
+          "Origin": "USA",
+          "Weight_in_lbs": 3520,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 16.9,
+          "Cylinders": 6,
+          "Displacement": 231,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 20.5,
+          "Name": "buick skylark",
+          "Origin": "USA",
+          "Weight_in_lbs": 3425,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 17.7,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 19,
+          "Name": "plymouth volare custom",
+          "Origin": "USA",
+          "Weight_in_lbs": 3630,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 6,
+          "Displacement": 250,
+          "Horsepower": 98,
+          "Miles_per_Gallon": 18.5,
+          "Name": "ford granada",
+          "Origin": "USA",
+          "Weight_in_lbs": 3525,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 11.1,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 180,
+          "Miles_per_Gallon": 16,
+          "Name": "pontiac grand prix lj",
+          "Origin": "USA",
+          "Weight_in_lbs": 4220,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 11.4,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 170,
+          "Miles_per_Gallon": 15.5,
+          "Name": "chevrolet monte carlo landau",
+          "Origin": "USA",
+          "Weight_in_lbs": 4165,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 12.2,
+          "Cylinders": 8,
+          "Displacement": 400,
+          "Horsepower": 190,
+          "Miles_per_Gallon": 15.5,
+          "Name": "chrysler cordoba",
+          "Origin": "USA",
+          "Weight_in_lbs": 4325,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 8,
+          "Displacement": 351,
+          "Horsepower": 149,
+          "Miles_per_Gallon": 16,
+          "Name": "ford thunderbird",
+          "Origin": "USA",
+          "Weight_in_lbs": 4335,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 78,
+          "Miles_per_Gallon": 29,
+          "Name": "volkswagen rabbit custom",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1940,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 24.5,
+          "Name": "pontiac sunbird coupe",
+          "Origin": "USA",
+          "Weight_in_lbs": 2740,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 18.2,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 26,
+          "Name": "toyota corolla liftback",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2265,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 15.8,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 89,
+          "Miles_per_Gallon": 25.5,
+          "Name": "ford mustang ii 2+2",
+          "Origin": "USA",
+          "Weight_in_lbs": 2755,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 63,
+          "Miles_per_Gallon": 30.5,
+          "Name": "chevrolet chevette",
+          "Origin": "USA",
+          "Weight_in_lbs": 2051,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 15.9,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 83,
+          "Miles_per_Gallon": 33.5,
+          "Name": "dodge colt m/m",
+          "Origin": "USA",
+          "Weight_in_lbs": 2075,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 16.4,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 30,
+          "Name": "subaru dl",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1985,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 14.1,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 78,
+          "Miles_per_Gallon": 30.5,
+          "Name": "volkswagen dasher",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2190,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 6,
+          "Displacement": 146,
+          "Horsepower": 97,
+          "Miles_per_Gallon": 22,
+          "Name": "datsun 810",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2815,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 12.8,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 21.5,
+          "Name": "bmw 320i",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2600,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 13.5,
+          "Cylinders": 3,
+          "Displacement": 80,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 21.5,
+          "Name": "mazda rx-4",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2720,
+          "Year": "1977-01-01"
+         },
+         {
+          "Acceleration": 21.5,
+          "Cylinders": 4,
+          "Displacement": 90,
+          "Horsepower": 48,
+          "Miles_per_Gallon": 43.1,
+          "Name": "volkswagen rabbit custom diesel",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1985,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 14.4,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 66,
+          "Miles_per_Gallon": 36.1,
+          "Name": "ford fiesta",
+          "Origin": "USA",
+          "Weight_in_lbs": 1800,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 19.4,
+          "Cylinders": 4,
+          "Displacement": 78,
+          "Horsepower": 52,
+          "Miles_per_Gallon": 32.8,
+          "Name": "mazda glc deluxe",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1985,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 18.6,
+          "Cylinders": 4,
+          "Displacement": 85,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 39.4,
+          "Name": "datsun b210 gx",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2070,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 16.4,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 60,
+          "Miles_per_Gallon": 36.1,
+          "Name": "honda civic cvcc",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1800,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 8,
+          "Displacement": 260,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 19.9,
+          "Name": "oldsmobile cutlass salon brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 3365,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 13.2,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 140,
+          "Miles_per_Gallon": 19.4,
+          "Name": "dodge diplomat",
+          "Origin": "USA",
+          "Weight_in_lbs": 3735,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 12.8,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 139,
+          "Miles_per_Gallon": 20.2,
+          "Name": "mercury monarch ghia",
+          "Origin": "USA",
+          "Weight_in_lbs": 3570,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 19.2,
+          "Cylinders": 6,
+          "Displacement": 231,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 19.2,
+          "Name": "pontiac phoenix lj",
+          "Origin": "USA",
+          "Weight_in_lbs": 3535,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 18.2,
+          "Cylinders": 6,
+          "Displacement": 200,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 20.5,
+          "Name": "chevrolet malibu",
+          "Origin": "USA",
+          "Weight_in_lbs": 3155,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 15.8,
+          "Cylinders": 6,
+          "Displacement": 200,
+          "Horsepower": 85,
+          "Miles_per_Gallon": 20.2,
+          "Name": "ford fairmont (auto)",
+          "Origin": "USA",
+          "Weight_in_lbs": 2965,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 15.4,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 25.1,
+          "Name": "ford fairmont (man)",
+          "Origin": "USA",
+          "Weight_in_lbs": 2720,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 17.2,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 20.5,
+          "Name": "plymouth volare",
+          "Origin": "USA",
+          "Weight_in_lbs": 3430,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 17.2,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 19.4,
+          "Name": "amc concord",
+          "Origin": "USA",
+          "Weight_in_lbs": 3210,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 15.8,
+          "Cylinders": 6,
+          "Displacement": 231,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 20.6,
+          "Name": "buick century special",
+          "Origin": "USA",
+          "Weight_in_lbs": 3380,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 16.7,
+          "Cylinders": 6,
+          "Displacement": 200,
+          "Horsepower": 85,
+          "Miles_per_Gallon": 20.8,
+          "Name": "mercury zephyr",
+          "Origin": "USA",
+          "Weight_in_lbs": 3070,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 18.7,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 18.6,
+          "Name": "dodge aspen",
+          "Origin": "USA",
+          "Weight_in_lbs": 3620,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 15.1,
+          "Cylinders": 6,
+          "Displacement": 258,
+          "Horsepower": 120,
+          "Miles_per_Gallon": 18.1,
+          "Name": "amc concord d/l",
+          "Origin": "USA",
+          "Weight_in_lbs": 3410,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 13.2,
+          "Cylinders": 8,
+          "Displacement": 305,
+          "Horsepower": 145,
+          "Miles_per_Gallon": 19.2,
+          "Name": "chevrolet monte carlo landau",
+          "Origin": "USA",
+          "Weight_in_lbs": 3425,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 13.4,
+          "Cylinders": 6,
+          "Displacement": 231,
+          "Horsepower": 165,
+          "Miles_per_Gallon": 17.7,
+          "Name": "buick regal sport coupe (turbo)",
+          "Origin": "USA",
+          "Weight_in_lbs": 3445,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 11.2,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 139,
+          "Miles_per_Gallon": 18.1,
+          "Name": "ford futura",
+          "Origin": "USA",
+          "Weight_in_lbs": 3205,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 13.7,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 140,
+          "Miles_per_Gallon": 17.5,
+          "Name": "dodge magnum xe",
+          "Origin": "USA",
+          "Weight_in_lbs": 4080,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 68,
+          "Miles_per_Gallon": 30,
+          "Name": "chevrolet chevette",
+          "Origin": "USA",
+          "Weight_in_lbs": 2155,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 14.2,
+          "Cylinders": 4,
+          "Displacement": 134,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 27.5,
+          "Name": "toyota corona",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2560,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 14.7,
+          "Cylinders": 4,
+          "Displacement": 119,
+          "Horsepower": 97,
+          "Miles_per_Gallon": 27.2,
+          "Name": "datsun 510",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2300,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 105,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 30.9,
+          "Name": "dodge omni",
+          "Origin": "USA",
+          "Weight_in_lbs": 2230,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 14.8,
+          "Cylinders": 4,
+          "Displacement": 134,
+          "Horsepower": 95,
+          "Miles_per_Gallon": 21.1,
+          "Name": "toyota celica gt liftback",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2515,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 16.7,
+          "Cylinders": 4,
+          "Displacement": 156,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 23.2,
+          "Name": "plymouth sapporo",
+          "Origin": "USA",
+          "Weight_in_lbs": 2745,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 17.6,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": 85,
+          "Miles_per_Gallon": 23.8,
+          "Name": "oldsmobile starfire sx",
+          "Origin": "USA",
+          "Weight_in_lbs": 2855,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 14.9,
+          "Cylinders": 4,
+          "Displacement": 119,
+          "Horsepower": 97,
+          "Miles_per_Gallon": 23.9,
+          "Name": "datsun 200-sx",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2405,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 15.9,
+          "Cylinders": 5,
+          "Displacement": 131,
+          "Horsepower": 103,
+          "Miles_per_Gallon": 20.3,
+          "Name": "audi 5000",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2830,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 13.6,
+          "Cylinders": 6,
+          "Displacement": 163,
+          "Horsepower": 125,
+          "Miles_per_Gallon": 17,
+          "Name": "volvo 264gl",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3140,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 15.7,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 115,
+          "Miles_per_Gallon": 21.6,
+          "Name": "saab 99gle",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2795,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 15.8,
+          "Cylinders": 6,
+          "Displacement": 163,
+          "Horsepower": 133,
+          "Miles_per_Gallon": 16.2,
+          "Name": "peugeot 604sl",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3410,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 14.9,
+          "Cylinders": 4,
+          "Displacement": 89,
+          "Horsepower": 71,
+          "Miles_per_Gallon": 31.5,
+          "Name": "volkswagen scirocco",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1990,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 16.6,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 68,
+          "Miles_per_Gallon": 29.5,
+          "Name": "honda Accelerationord lx",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2135,
+          "Year": "1978-01-01"
+         },
+         {
+          "Acceleration": 15.4,
+          "Cylinders": 6,
+          "Displacement": 231,
+          "Horsepower": 115,
+          "Miles_per_Gallon": 21.5,
+          "Name": "pontiac lemans v6",
+          "Origin": "USA",
+          "Weight_in_lbs": 3245,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 18.2,
+          "Cylinders": 6,
+          "Displacement": 200,
+          "Horsepower": 85,
+          "Miles_per_Gallon": 19.8,
+          "Name": "mercury zephyr 6",
+          "Origin": "USA",
+          "Weight_in_lbs": 2990,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 17.3,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 22.3,
+          "Name": "ford fairmont 4",
+          "Origin": "USA",
+          "Weight_in_lbs": 2890,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 18.2,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 20.2,
+          "Name": "amc concord dl 6",
+          "Origin": "USA",
+          "Weight_in_lbs": 3265,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 16.6,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 20.6,
+          "Name": "dodge aspen 6",
+          "Origin": "USA",
+          "Weight_in_lbs": 3360,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 15.4,
+          "Cylinders": 8,
+          "Displacement": 305,
+          "Horsepower": 130,
+          "Miles_per_Gallon": 17,
+          "Name": "chevrolet caprice classic",
+          "Origin": "USA",
+          "Weight_in_lbs": 3840,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 13.4,
+          "Cylinders": 8,
+          "Displacement": 302,
+          "Horsepower": 129,
+          "Miles_per_Gallon": 17.6,
+          "Name": "ford ltd landau",
+          "Origin": "USA",
+          "Weight_in_lbs": 3725,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 13.2,
+          "Cylinders": 8,
+          "Displacement": 351,
+          "Horsepower": 138,
+          "Miles_per_Gallon": 16.5,
+          "Name": "mercury grand marquis",
+          "Origin": "USA",
+          "Weight_in_lbs": 3955,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 15.2,
+          "Cylinders": 8,
+          "Displacement": 318,
+          "Horsepower": 135,
+          "Miles_per_Gallon": 18.2,
+          "Name": "dodge st. regis",
+          "Origin": "USA",
+          "Weight_in_lbs": 3830,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 14.9,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 155,
+          "Miles_per_Gallon": 16.9,
+          "Name": "buick estate wagon (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4360,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 14.3,
+          "Cylinders": 8,
+          "Displacement": 351,
+          "Horsepower": 142,
+          "Miles_per_Gallon": 15.5,
+          "Name": "ford country squire (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 4054,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 8,
+          "Displacement": 267,
+          "Horsepower": 125,
+          "Miles_per_Gallon": 19.2,
+          "Name": "chevrolet malibu classic (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 3605,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 8,
+          "Displacement": 360,
+          "Horsepower": 150,
+          "Miles_per_Gallon": 18.5,
+          "Name": "chrysler lebaron town @ country (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 3940,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 14,
+          "Cylinders": 4,
+          "Displacement": 89,
+          "Horsepower": 71,
+          "Miles_per_Gallon": 31.9,
+          "Name": "vw rabbit custom",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1925,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 15.2,
+          "Cylinders": 4,
+          "Displacement": 86,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 34.1,
+          "Name": "maxda glc deluxe",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1975,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 14.4,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 80,
+          "Miles_per_Gallon": 35.7,
+          "Name": "dodge colt hatchback custom",
+          "Origin": "USA",
+          "Weight_in_lbs": 1915,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 80,
+          "Miles_per_Gallon": 27.4,
+          "Name": "amc spirit dl",
+          "Origin": "USA",
+          "Weight_in_lbs": 2670,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 20.1,
+          "Cylinders": 5,
+          "Displacement": 183,
+          "Horsepower": 77,
+          "Miles_per_Gallon": 25.4,
+          "Name": "mercedes benz 300d",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3530,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 17.4,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 125,
+          "Miles_per_Gallon": 23,
+          "Name": "cadillac eldorado",
+          "Origin": "USA",
+          "Weight_in_lbs": 3900,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 24.8,
+          "Cylinders": 4,
+          "Displacement": 141,
+          "Horsepower": 71,
+          "Miles_per_Gallon": 27.2,
+          "Name": "peugeot 504",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3190,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 22.2,
+          "Cylinders": 8,
+          "Displacement": 260,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 23.9,
+          "Name": "oldsmobile cutlass salon brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 3420,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 13.2,
+          "Cylinders": 4,
+          "Displacement": 105,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 34.2,
+          "Name": "plymouth horizon",
+          "Origin": "USA",
+          "Weight_in_lbs": 2200,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 14.9,
+          "Cylinders": 4,
+          "Displacement": 105,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 34.5,
+          "Name": "plymouth horizon tc3",
+          "Origin": "USA",
+          "Weight_in_lbs": 2150,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 19.2,
+          "Cylinders": 4,
+          "Displacement": 85,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 31.8,
+          "Name": "datsun 210",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2020,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 14.7,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 69,
+          "Miles_per_Gallon": 37.3,
+          "Name": "fiat strada custom",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2130,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 28.4,
+          "Name": "buick skylark limited",
+          "Origin": "USA",
+          "Weight_in_lbs": 2670,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 11.3,
+          "Cylinders": 6,
+          "Displacement": 173,
+          "Horsepower": 115,
+          "Miles_per_Gallon": 28.8,
+          "Name": "chevrolet citation",
+          "Origin": "USA",
+          "Weight_in_lbs": 2595,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 12.9,
+          "Cylinders": 6,
+          "Displacement": 173,
+          "Horsepower": 115,
+          "Miles_per_Gallon": 26.8,
+          "Name": "oldsmobile omega brougham",
+          "Origin": "USA",
+          "Weight_in_lbs": 2700,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 13.2,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 33.5,
+          "Name": "pontiac phoenix",
+          "Origin": "USA",
+          "Weight_in_lbs": 2556,
+          "Year": "1979-01-01"
+         },
+         {
+          "Acceleration": 14.7,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 76,
+          "Miles_per_Gallon": 41.5,
+          "Name": "vw rabbit",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2144,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 18.8,
+          "Cylinders": 4,
+          "Displacement": 89,
+          "Horsepower": 60,
+          "Miles_per_Gallon": 38.1,
+          "Name": "toyota corolla tercel",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1968,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 32.1,
+          "Name": "chevrolet chevette",
+          "Origin": "USA",
+          "Weight_in_lbs": 2120,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 16.4,
+          "Cylinders": 4,
+          "Displacement": 86,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 37.2,
+          "Name": "datsun 310",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2019,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 16.5,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 28,
+          "Name": "chevrolet citation",
+          "Origin": "USA",
+          "Weight_in_lbs": 2678,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 18.1,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 26.4,
+          "Name": "ford fairmont",
+          "Origin": "USA",
+          "Weight_in_lbs": 2870,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 20.1,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 24.3,
+          "Name": "amc concord",
+          "Origin": "USA",
+          "Weight_in_lbs": 3003,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 18.7,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 19.1,
+          "Name": "dodge aspen",
+          "Origin": "USA",
+          "Weight_in_lbs": 3381,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 15.8,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 78,
+          "Miles_per_Gallon": 34.3,
+          "Name": "audi 4000",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2188,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 15.5,
+          "Cylinders": 4,
+          "Displacement": 134,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 29.8,
+          "Name": "toyota corona liftback",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2711,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 17.5,
+          "Cylinders": 4,
+          "Displacement": 120,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 31.3,
+          "Name": "mazda 626",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2542,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 4,
+          "Displacement": 119,
+          "Horsepower": 92,
+          "Miles_per_Gallon": 37,
+          "Name": "datsun 510 hatchback",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2434,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 15.2,
+          "Cylinders": 4,
+          "Displacement": 108,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 32.2,
+          "Name": "toyota corolla",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2265,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 17.9,
+          "Cylinders": 4,
+          "Displacement": 86,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 46.6,
+          "Name": "mazda glc",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2110,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 14.4,
+          "Cylinders": 4,
+          "Displacement": 156,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 27.9,
+          "Name": "dodge colt",
+          "Origin": "USA",
+          "Weight_in_lbs": 2800,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 19.2,
+          "Cylinders": 4,
+          "Displacement": 85,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 40.8,
+          "Name": "datsun 210",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2110,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 21.7,
+          "Cylinders": 4,
+          "Displacement": 90,
+          "Horsepower": 48,
+          "Miles_per_Gallon": 44.3,
+          "Name": "vw rabbit c (diesel)",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2085,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 23.7,
+          "Cylinders": 4,
+          "Displacement": 90,
+          "Horsepower": 48,
+          "Miles_per_Gallon": 43.4,
+          "Name": "vw dasher (diesel)",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2335,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 19.9,
+          "Cylinders": 5,
+          "Displacement": 121,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 36.4,
+          "Name": "audi 5000s (diesel)",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2950,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 21.8,
+          "Cylinders": 4,
+          "Displacement": 146,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 30,
+          "Name": "mercedes-benz 240d",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3250,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 13.8,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 44.6,
+          "Name": "honda civic 1500 gl",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1850,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 17.3,
+          "Cylinders": 4,
+          "Displacement": 85,
+          "Horsepower": null,
+          "Miles_per_Gallon": 40.9,
+          "Name": "renault lecar deluxe",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1835,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 18,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 33.8,
+          "Name": "subaru dl",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2145,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 15.3,
+          "Cylinders": 4,
+          "Displacement": 89,
+          "Horsepower": 62,
+          "Miles_per_Gallon": 29.8,
+          "Name": "vokswagen rabbit",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1845,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 11.4,
+          "Cylinders": 6,
+          "Displacement": 168,
+          "Horsepower": 132,
+          "Miles_per_Gallon": 32.7,
+          "Name": "datsun 280-zx",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2910,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 12.5,
+          "Cylinders": 3,
+          "Displacement": 70,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 23.7,
+          "Name": "mazda rx-7 gs",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2420,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 15.1,
+          "Cylinders": 4,
+          "Displacement": 122,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 35,
+          "Name": "triumph tr7 coupe",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2500,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 14.3,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": null,
+          "Miles_per_Gallon": 23.6,
+          "Name": "ford mustang cobra",
+          "Origin": "USA",
+          "Weight_in_lbs": 2905,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 4,
+          "Displacement": 107,
+          "Horsepower": 72,
+          "Miles_per_Gallon": 32.4,
+          "Name": "honda Accelerationord",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2290,
+          "Year": "1980-01-01"
+         },
+         {
+          "Acceleration": 15.7,
+          "Cylinders": 4,
+          "Displacement": 135,
+          "Horsepower": 84,
+          "Miles_per_Gallon": 27.2,
+          "Name": "plymouth reliant",
+          "Origin": "USA",
+          "Weight_in_lbs": 2490,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.4,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": 84,
+          "Miles_per_Gallon": 26.6,
+          "Name": "buick skylark",
+          "Origin": "USA",
+          "Weight_in_lbs": 2635,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.4,
+          "Cylinders": 4,
+          "Displacement": 156,
+          "Horsepower": 92,
+          "Miles_per_Gallon": 25.8,
+          "Name": "dodge aries wagon (sw)",
+          "Origin": "USA",
+          "Weight_in_lbs": 2620,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 12.6,
+          "Cylinders": 6,
+          "Displacement": 173,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 23.5,
+          "Name": "chevrolet citation",
+          "Origin": "USA",
+          "Weight_in_lbs": 2725,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 12.9,
+          "Cylinders": 4,
+          "Displacement": 135,
+          "Horsepower": 84,
+          "Miles_per_Gallon": 30,
+          "Name": "plymouth reliant",
+          "Origin": "USA",
+          "Weight_in_lbs": 2385,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.9,
+          "Cylinders": 4,
+          "Displacement": 79,
+          "Horsepower": 58,
+          "Miles_per_Gallon": 39.1,
+          "Name": "toyota starlet",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1755,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.4,
+          "Cylinders": 4,
+          "Displacement": 86,
+          "Horsepower": 64,
+          "Miles_per_Gallon": 39,
+          "Name": "plymouth champ",
+          "Origin": "USA",
+          "Weight_in_lbs": 1875,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.1,
+          "Cylinders": 4,
+          "Displacement": 81,
+          "Horsepower": 60,
+          "Miles_per_Gallon": 35.1,
+          "Name": "honda civic 1300",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1760,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 17.8,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 32.3,
+          "Name": "subaru",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2065,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 19.4,
+          "Cylinders": 4,
+          "Displacement": 85,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 37,
+          "Name": "datsun 210",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1975,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 17.3,
+          "Cylinders": 4,
+          "Displacement": 89,
+          "Horsepower": 62,
+          "Miles_per_Gallon": 37.7,
+          "Name": "toyota tercel",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2050,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 68,
+          "Miles_per_Gallon": 34.1,
+          "Name": "mazda glc 4",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1985,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.9,
+          "Cylinders": 4,
+          "Displacement": 105,
+          "Horsepower": 63,
+          "Miles_per_Gallon": 34.7,
+          "Name": "plymouth horizon 4",
+          "Origin": "USA",
+          "Weight_in_lbs": 2215,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.2,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 34.4,
+          "Name": "ford escort 4w",
+          "Origin": "USA",
+          "Weight_in_lbs": 2045,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 20.7,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 65,
+          "Miles_per_Gallon": 29.9,
+          "Name": "ford escort 2h",
+          "Origin": "USA",
+          "Weight_in_lbs": 2380,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.2,
+          "Cylinders": 4,
+          "Displacement": 105,
+          "Horsepower": 74,
+          "Miles_per_Gallon": 33,
+          "Name": "volkswagen jetta",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2190,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 15.8,
+          "Cylinders": 4,
+          "Displacement": 100,
+          "Horsepower": null,
+          "Miles_per_Gallon": 34.5,
+          "Name": "renault 18i",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2320,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.4,
+          "Cylinders": 4,
+          "Displacement": 107,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 33.7,
+          "Name": "honda prelude",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2210,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.8,
+          "Cylinders": 4,
+          "Displacement": 108,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 32.4,
+          "Name": "toyota corolla",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2350,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.8,
+          "Cylinders": 4,
+          "Displacement": 119,
+          "Horsepower": 100,
+          "Miles_per_Gallon": 32.9,
+          "Name": "datsun 200sx",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2615,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 18.3,
+          "Cylinders": 4,
+          "Displacement": 120,
+          "Horsepower": 74,
+          "Miles_per_Gallon": 31.6,
+          "Name": "mazda 626",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2635,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 20.4,
+          "Cylinders": 4,
+          "Displacement": 141,
+          "Horsepower": 80,
+          "Miles_per_Gallon": 28.1,
+          "Name": "peugeot 505s turbo diesel",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3230,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 15.4,
+          "Cylinders": 4,
+          "Displacement": 121,
+          "Horsepower": 110,
+          "Miles_per_Gallon": null,
+          "Name": "saab 900s",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2800,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 19.6,
+          "Cylinders": 6,
+          "Displacement": 145,
+          "Horsepower": 76,
+          "Miles_per_Gallon": 30.7,
+          "Name": "volvo diesel",
+          "Origin": "Europe",
+          "Weight_in_lbs": 3160,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 12.6,
+          "Cylinders": 6,
+          "Displacement": 168,
+          "Horsepower": 116,
+          "Miles_per_Gallon": 25.4,
+          "Name": "toyota cressida",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2900,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 13.8,
+          "Cylinders": 6,
+          "Displacement": 146,
+          "Horsepower": 120,
+          "Miles_per_Gallon": 24.2,
+          "Name": "datsun 810 maxima",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2930,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 15.8,
+          "Cylinders": 6,
+          "Displacement": 231,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 22.4,
+          "Name": "buick century",
+          "Origin": "USA",
+          "Weight_in_lbs": 3415,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 19,
+          "Cylinders": 8,
+          "Displacement": 350,
+          "Horsepower": 105,
+          "Miles_per_Gallon": 26.6,
+          "Name": "oldsmobile cutlass ls",
+          "Origin": "USA",
+          "Weight_in_lbs": 3725,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 17.1,
+          "Cylinders": 6,
+          "Displacement": 200,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 20.2,
+          "Name": "ford granada gl",
+          "Origin": "USA",
+          "Weight_in_lbs": 3060,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.6,
+          "Cylinders": 6,
+          "Displacement": 225,
+          "Horsepower": 85,
+          "Miles_per_Gallon": 17.6,
+          "Name": "chrysler lebaron salon",
+          "Origin": "USA",
+          "Weight_in_lbs": 3465,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 19.6,
+          "Cylinders": 4,
+          "Displacement": 112,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 28,
+          "Name": "chevrolet cavalier",
+          "Origin": "USA",
+          "Weight_in_lbs": 2605,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 18.6,
+          "Cylinders": 4,
+          "Displacement": 112,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 27,
+          "Name": "chevrolet cavalier wagon",
+          "Origin": "USA",
+          "Weight_in_lbs": 2640,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 18,
+          "Cylinders": 4,
+          "Displacement": 112,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 34,
+          "Name": "chevrolet cavalier 2-door",
+          "Origin": "USA",
+          "Weight_in_lbs": 2395,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.2,
+          "Cylinders": 4,
+          "Displacement": 112,
+          "Horsepower": 85,
+          "Miles_per_Gallon": 31,
+          "Name": "pontiac j2000 se hatchback",
+          "Origin": "USA",
+          "Weight_in_lbs": 2575,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16,
+          "Cylinders": 4,
+          "Displacement": 135,
+          "Horsepower": 84,
+          "Miles_per_Gallon": 29,
+          "Name": "dodge aries se",
+          "Origin": "USA",
+          "Weight_in_lbs": 2525,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 18,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 27,
+          "Name": "pontiac phoenix",
+          "Origin": "USA",
+          "Weight_in_lbs": 2735,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.4,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 92,
+          "Miles_per_Gallon": 24,
+          "Name": "ford fairmont futura",
+          "Origin": "USA",
+          "Weight_in_lbs": 2865,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 20.5,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": null,
+          "Miles_per_Gallon": 23,
+          "Name": "amc concord dl",
+          "Origin": "USA",
+          "Weight_in_lbs": 3035,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 15.3,
+          "Cylinders": 4,
+          "Displacement": 105,
+          "Horsepower": 74,
+          "Miles_per_Gallon": 36,
+          "Name": "volkswagen rabbit l",
+          "Origin": "Europe",
+          "Weight_in_lbs": 1980,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 18.2,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 68,
+          "Miles_per_Gallon": 37,
+          "Name": "mazda glc custom l",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2025,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 17.6,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 68,
+          "Miles_per_Gallon": 31,
+          "Name": "mazda glc custom",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1970,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.7,
+          "Cylinders": 4,
+          "Displacement": 105,
+          "Horsepower": 63,
+          "Miles_per_Gallon": 38,
+          "Name": "plymouth horizon miser",
+          "Origin": "USA",
+          "Weight_in_lbs": 2125,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 17.3,
+          "Cylinders": 4,
+          "Displacement": 98,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 36,
+          "Name": "mercury lynx l",
+          "Origin": "USA",
+          "Weight_in_lbs": 2125,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 120,
+          "Horsepower": 88,
+          "Miles_per_Gallon": 36,
+          "Name": "nissan stanza xe",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2160,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 107,
+          "Horsepower": 75,
+          "Miles_per_Gallon": 36,
+          "Name": "honda Accelerationord",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2205,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.9,
+          "Cylinders": 4,
+          "Displacement": 108,
+          "Horsepower": 70,
+          "Miles_per_Gallon": 34,
+          "Name": "toyota corolla",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2245,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 15,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 38,
+          "Name": "honda civic",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1965,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 15.7,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 32,
+          "Name": "honda civic (auto)",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1965,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.2,
+          "Cylinders": 4,
+          "Displacement": 91,
+          "Horsepower": 67,
+          "Miles_per_Gallon": 38,
+          "Name": "datsun 310 gx",
+          "Origin": "Japan",
+          "Weight_in_lbs": 1995,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 16.4,
+          "Cylinders": 6,
+          "Displacement": 181,
+          "Horsepower": 110,
+          "Miles_per_Gallon": 25,
+          "Name": "buick century limited",
+          "Origin": "USA",
+          "Weight_in_lbs": 2945,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 17,
+          "Cylinders": 6,
+          "Displacement": 262,
+          "Horsepower": 85,
+          "Miles_per_Gallon": 38,
+          "Name": "oldsmobile cutlass ciera (diesel)",
+          "Origin": "USA",
+          "Weight_in_lbs": 3015,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.5,
+          "Cylinders": 4,
+          "Displacement": 156,
+          "Horsepower": 92,
+          "Miles_per_Gallon": 26,
+          "Name": "chrysler lebaron medallion",
+          "Origin": "USA",
+          "Weight_in_lbs": 2585,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 14.7,
+          "Cylinders": 6,
+          "Displacement": 232,
+          "Horsepower": 112,
+          "Miles_per_Gallon": 22,
+          "Name": "ford granada l",
+          "Origin": "USA",
+          "Weight_in_lbs": 2835,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 13.9,
+          "Cylinders": 4,
+          "Displacement": 144,
+          "Horsepower": 96,
+          "Miles_per_Gallon": 32,
+          "Name": "toyota celica gt",
+          "Origin": "Japan",
+          "Weight_in_lbs": 2665,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 13,
+          "Cylinders": 4,
+          "Displacement": 135,
+          "Horsepower": 84,
+          "Miles_per_Gallon": 36,
+          "Name": "dodge charger 2.2",
+          "Origin": "USA",
+          "Weight_in_lbs": 2370,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 17.3,
+          "Cylinders": 4,
+          "Displacement": 151,
+          "Horsepower": 90,
+          "Miles_per_Gallon": 27,
+          "Name": "chevrolet camaro",
+          "Origin": "USA",
+          "Weight_in_lbs": 2950,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 15.6,
+          "Cylinders": 4,
+          "Displacement": 140,
+          "Horsepower": 86,
+          "Miles_per_Gallon": 27,
+          "Name": "ford mustang gl",
+          "Origin": "USA",
+          "Weight_in_lbs": 2790,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 24.6,
+          "Cylinders": 4,
+          "Displacement": 97,
+          "Horsepower": 52,
+          "Miles_per_Gallon": 44,
+          "Name": "vw pickup",
+          "Origin": "Europe",
+          "Weight_in_lbs": 2130,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 11.6,
+          "Cylinders": 4,
+          "Displacement": 135,
+          "Horsepower": 84,
+          "Miles_per_Gallon": 32,
+          "Name": "dodge rampage",
+          "Origin": "USA",
+          "Weight_in_lbs": 2295,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 18.6,
+          "Cylinders": 4,
+          "Displacement": 120,
+          "Horsepower": 79,
+          "Miles_per_Gallon": 28,
+          "Name": "ford ranger",
+          "Origin": "USA",
+          "Weight_in_lbs": 2625,
+          "Year": "1982-01-01"
+         },
+         {
+          "Acceleration": 19.4,
+          "Cylinders": 4,
+          "Displacement": 119,
+          "Horsepower": 82,
+          "Miles_per_Gallon": 31,
+          "Name": "chevy s-10",
+          "Origin": "USA",
+          "Weight_in_lbs": 2720,
+          "Year": "1982-01-01"
+         }
+        ]
+       },
+       "encoding": {
+        "color": {
+         "field": "Origin",
+         "type": "nominal"
+        },
+        "x": {
+         "field": "Horsepower",
+         "type": "quantitative"
+        },
+        "y": {
+         "field": "Miles_per_Gallon",
+         "type": "quantitative"
+        }
+       },
+       "mark": "point"
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAg0AAAFfCAYAAADNtv/1AAAgAElEQVR4Xux9CXiU1fX+e+43k0kmCYSELBB23HDfxX1tq4ArhkWrtqUurfqr2soioFFAQdS/da1LrUurkODOVqstarWl7oqAC7IEJAtLSDKTTGa+e/7PmXzRISRkkkyST7z3eXzUzP3unO899577zr1nIZhmEDAIGAQMAgYBg4BBIA4EKI4+potBwCBgEDAIGAQMAgYBGNJgJoFBwCBgEDAIGAQMAnEhYEhDXDCZTgYBg4BBwCBgEDAIGNJg5oBBwCBgEDAIGAQMAnEhYEhDXDCZTgYBg4BBwCBgEDAIGNJg5oBBwCBgEDAIGAQMAnEh4DbSkAQgJUbyAIAIAA+AgQBqAJTF9Wamk0HAIGAQMAgYBAwCCUXAbaRhPIB7AbzukITfAFgD4DUAnwA4BcAMAPMSioIZzCBgEDAIGAQMAgaBVhFwG2m4BUAxgJUxkl8EYD8ANwNIBfANgL0BVLX6dqaDQcAgYBAwCBgEDAIJQ8BtpGE+gDHO2wl5uBzAZACvAngXiOaVkFOInwPYnDAUzEAGAYOAQcAgYBAwCLSKgJtIg/gt3AbgWQBfA7gbwGoAPwNwK4D3HNIgVxNT5MRh9uzZclUxLfYte/fuHTn11FNlLNMMAgYBg4BBwCDQFgQqhw4d2qstD8TRNxuA+OuJT96OOPq7uoubSIMAJcDWO4gdBeASAJ8BWOucMCQ7vg3DAWxvimxRUZG1du3ayKRJk7r1vdasWcNDhw7tVhkEGzfIYWT4fpYaLBqwcAMObpHDDVi4QYY9VB9CPh4CMC5mr7oJwFzHwb/pFnYxgHuc6/hd9reYzo8D2AfAqQDsrmYY3b6xxbywALwewBAAWwDcAWCTcw3xOwcg+WwpgAMB1BrSsPvp4gZjYGQwpKHpLHXDnNhDN6l27R9GH52yRhWANxznfSEOsm/NBHAwgN875KCpvo4HcK5z4i6nEi21ywD0APAgAN0upXfgITeRBnmNqwE84LzPfwGMdE4UngDwC+fvhwD4tLl3NicNO6PiBmNgZOgUg9TuJW/0YfRhSFzLyyeB60Oc91cBkL1LfPNkc/cDWOZEBsrnsvnLD+E6AF8C+MohDeL0L6RhLID7ALztjCVpB2SPlL9LUMD9AE5yxv/C+ewDAP/nXPG3207s7kG3kQaRVYCVa4htTQTPARB0wGz2nQxpMKShuYmRQEPQoUXoBjmMDIY0GNLQJaThQicSUK7Z34/5xusd5345LS8E8FsA1Q6BsJzTAyEUciIhBOPvAP4B4C4A5c7VhVxvyH54vvOPBA0sASCBBE86gQPnddYphBtJQ7sNsyENhjQY0rD75WNIgyENhjR0CWkoAFAE4FDHD6/xS38F4M+OT8K1AA4HcIZz2iBEQ64chDQIIZAreiEXFQAkZ5GQDPlMAgMGARBicEHMM+IHIc/3dz7rlKsLQxraTVG6ZOJ1SDqzQTTA5wYc3CKHG7BwgwxGH+4iT3ugPg5yrtEl0m+2g7bsty8CONbJNSQ+Do2bv2zwsaRB/PiEKAhJEDIg1/Nz4iANcp0RO2aH9pDmHjakIeGQmk0qFlI3bBBukGEPNIrtXjlGH+7asI0+OkUfEvYv1wvi3CjE4d8AJjib/1QAtzv+Ci2RBjmBkJxE4hPxlnPt0Hg9sbuTBkMa2mKZzPWEuZ4w1xPmeiJem+GGzdLI0CkbdrxTYJd+CdZHcyGXkqxQ/BMkVFI2+FwAUj6h6UmDnC5IqOYfnahCcZKUa4zG64nG55peTzQds91YtPSgOWlIOKTmpMGcNDQ/qRJskNo1c40Me/Qm9YOdE3v4SVwmAC8AKcC4u1DKWP0d51xjvAlgBYBZTibkbi+hYEhDu5aZ+3/N7eGLsE1ac8NGafThrs3a6MPow82nko5fgiQ1jG2XAnimTcavEzob0tAJoJpNyl0GyejD6MOtG4Qb5qYbZDAkrtmNSNIPDHbSEJQCKOmE7arNQxrS0GbIWn/ALEKzSZlNquV1YtaHWR9mfbS+j7i1hyENnaAZYxSNUTRG0ZCGeEyLG2yFG2QwJw3xzBZ39DGkoRP0YBahIQ2GNBjSEI9pcYOtcIMMhjTEM1vc0ceQhk7Qg1mEhjQY0mBIQzymxQ22wg0yGNIQz2xxRx9DGjpBD2YRxkcauLBHZsjyZfnsihIqjBZt6ZRm9BGfPjoF/GYGNfow+vgxkeqfXV+USZ7wcEup/ZmUzcyrdX3N8r//v183ra/UVUuwQ99jSEOH4Gv+YWMUd28Ua27KyVUp6vdMGNbQk23F9HKyXfoUFSa+1KvRh9mkfkybVFtNmlkfnbc+Rk187nQmdQUIXoIu0QwLoHwQQgz96JLZF/2zBX1J5MTRAGL3aMkyKXkb6tuq40T2N6QhkWg6Y5lF2PIi5EKoWm/uvcw0WMgCgDKA+soTGvrJ9GnlzydaJUYfnWcU26Mrow+jjx8DiRsxZd4oxbhSg//JgZ4PLbl/REje+9jr70np5cu/SoFPY+Y/LZozflEzeMgPquUAJOU0O59LgqhHnSRR7Vl6CXnGkIaEwLjzIMYotmwUq2dkDVPkvZOZa8J26De9Cisra2/PO1lr/EGquaVOK5UqcAltRh9mk/oxbFLtXTRmfSR+fYyaWpTPNt8P1u8vmjNe6kzs0kZOnjcVjMMjlveav98+enOTDpIu+mEApzbz6DkANgL4EMBeAE4AMM8paCXE4nMArwBY6JTYngTgbgAnOlUxBzjZJs8G8D8AcoIh6a1nOLUufg+gsqX5ZEhDe1fabp4zi7DlRVhza+7pZNF1DLydNq30Tukppw9BT+4LAFn+SOm5ib6iMPpIvFHsyLIx+jD62NNJ3MjJ8woIuLSWQr94447Ltjb3vj/9w9M5SZ6kP7PGXxbdOe6FJn0kXfQHzkbeeNJQBeAxAJIZUmpRvAvgAACjnBoVQhakNPbfALwK4Ban2JUQCCnHLdca8vmRAOR0V/4upEN+qOU4Jbd/DuB0J2V14/fuJJohDR2xfi08a4xiy0YxcFvvI6A8Uhe+wu/ja+nGskDs38xJQydMyJgh3TA33SCDQOIGOYwMeyaBGjVp/kQGD1k0Z9xVu1vRIybOe4wUrV40e6ycBMQ2IQ1SGfNqAMr5R+pWyFVGLGmQaww5eXjAIQjHOFkkFwA4zCmEJacWUp57vkMWGr9L/n8uACnR/ZpT40LqZEx3Tijk+niXZkhDJ9hoNxgCtxpFLsxOC1jqMSJKA7gchDKwVG4jr7ZxT/otpf9KtEqMPvZMw9zReeKGeWFk2DPn5lmTnp1owRqwcM7Ya3ZPGp57mAhrFs0ZL5Uvm5IG8V9o7nriMgBfAPhvzEmDkAYpo30RgCGO78Npjj+EnEZc6fhISOVN6SvtOQD3ArjfKb3dGM3RSE7MSUNHjUy8z7vBELiVNIhcVbf03sfyWjcClBfFlCSneuTx1Klb5I4u4c3oY880zB2dKG6YF0aGPXNujpg8fzSBL9GBHmMbHSCbzldxiMz05c+D5qeauZ6Q04GXARzVJIJCKmXKFYJs6E855bXlqkIIQzEA8VMQv4ZPnGsG8X24A8AmAFK/Qk4ppJx2b6ePnGjIacNLAJYAOBSA+EBc7JxSmJOGjhqaeJ53gyFwM2kQ2Rigmltysz1Un5xSuH1DPLi2t4/Rx55pmNs7Hxqfc8O8MDLsmXPzlOtezEhNDj0KxtuL5oyTX/K7NLnC0MSHB+tqr1p27y+bOh4OBfB1M48JiZAojE9jPpPTjCdjThrkWmGk4wgp3d5x/v8nDrFofPRyAI8D6Of4T4hfQzUAueJY1dL6MtcTHbU8zTzvBkPgdtLQCbC3OKTRx55pmDs6h9wwL4wMe+7cHHHjs2cqS13NGm/o2h4PNxtyCfrjotljX2/HXE4CIP/IVUJLLRWAD0DjtYOcHmQAeMT5u5xaNDYLQE8A22NCPJsd162kQUJAcp0jFRG8R8wRjRzLiBfpLq2oqMhau3ZtZNKkSd36Xm4wBIY0uMsYGX0YfTRns9xgK9wgw566PkZMfPYnRNavY5M7Eam+YB1m5scX33nRP9pBGNr7iPg75DvXEe0dY6dsU+0epBMenOLc2xzs3M9IKImEnwhhWAvgpubuWwxp2FkTbjAGRgZ3bZZGH0YfTe21G+bEnkoa5L1On/JUljfiOcakke4EpuAMeTKAZU6c6XlOiIiQBAk9adabs1EUQxp+uKSh9A+5qf5UOz+d6rdQYVVCc7Ibo2g2SvMrv2WDbdaHu9ZH522tiRm5W4/xm3mFPg5hKHDCQiTcRMJHvozpK4ksmku7CUMafnikgefmpgZCdDU1ZCuLNmL+3I7gnvRby8oTMc2NUXSXUTT6MPowJC4Rlq17xnATaRA/BjlhkBjUiJOtSpJTHOtksJKUmhKGIndAEiZSNXv2bEl7Oa0pdAUFwjlMawsCm7fXomJHHSxF6NMrBZnp4j/T+c2/6ln4Kj6OfpGdkg2rbivAGpHUPqg+/DqA3DRFOx8P8w0GAYNA9yIwdOhQY3R2owI3gSOZrVY6oSTiyyCtyIkrjRb6cJwhpSrYBADfNH0vc9KwMyLx/KIrKCiygoP1ZFIY3vi0ZjADC5bMGfd0R5dvazLUzMibTwQ/aZ7pv7lsuZTLDnr8kugk2+bIH3pM3yJJTDrUWpOhQ4O34WE3yGFk+F5hBosGLNyAg1vkcAsWbTArXd7VTaRBwkckW1XYyXIl8aNyyiC+DHWOx2djPGn0pMGQht3Pl3gWwMiJz51Dii5nhk1Ey1lrDxMdpQikbXs6WVgPTecwaJAiqgTxJwtnj5cTobja7mTgK+ANDsh7Qapd+iNlFzTWnAjOzJvIwImJyhAZDw5xvUwHO7lBDiODIQ1Np7Eb5sSeTBqiP4Qs/3Am7K+IbYZeHQmHlvdMsO9WB81T3I+7iTTECi1FNKQwhxTOkMIaUkNcfBukSTarF5t7Q3PSsDMq8RiDkZPn/57ApzDT/EVzxv5VRpBsZgr8C5vpPwo4hIiltvt3jRmvtZSwpK0GKTAzT5KSZGnYc9OnVbzFhRkZAcv3sKSZZrKnp0117i7intK7dowHhw4MH/ejbpDDyGBIQ1vXaNwTvIMd98S5WTsr93QGXcHMXgZKiMgCOJ+ZQsz8aPr0Mjk5b63JNb1kdqxorWNXfO5W0tDcu8spRK1z6tAsNoY0tIc0zJtKwHBbY9aSO8dJLnOMnDj/VFJ8g9booRSqwFihQUsIfAARRkgfHbavWXz3xetbm6StGYLGqpcN4/C3Dfk5yGLwjlQfrpSCVq19R2uftyZDa88n6nM3yGFkMKTBkIaWV3Qi10dgRu4oEF3JzP9MLS97iO6PZnJEyfVIyeqdexUznQbCn1Knljbr2B8j5VIAtzlVLRNljto9zg+JNLT6koY0tJ00jJg8f7wCX6SBVZGwfoKVleVVfAEY+4Ci6UVLgqHaSxvTnI6cNH8uEe/HzHcsmjNeSrPutsWzCAO35R0FC78Eo38jebCY70yeXr6mtfHj+TweGeIZp6N93CCHkcGQBkMaOp80BGdm5TM8kj76/dRpZbc3942BWblTATociFyTOnXL5t3YFyksdQ+AjwBc51zVS2SZnLq/79SfkDD1yQDuBHCz+JU301fSSZ8FQNIaSI0KSZp4iri1tMW2GdLQFrTi7OsGwyyixiNHQWFRUrCW54H0cICkBCsgR2dgSaglhU9qiezLFs2+WNKLYuSkeTcT4ShNPHPxHeOXtwZJPDI0jlE7M2NgJOyrTbu1rIJaycnR2vfGft4WGdoyblv7ukEOI4MhDYY0dD5pqJ6ZV6CAS20V+EWPm6q3NveN1bfk5igv/ZlY/8U/vfyF3dgTKWEtzuFy0v4QAKleebhzhX+8U73ybwD+H4BnnJoTQiaa9pVrjtFOmWzxF5SS2gMckhG3OTOkIW6o4u/oBsMcL2kY8YfnjlEemqYZeQRkMdhLoFqAVrDWO5RFveV6wta0EIRsS/EEBoWByIRGIrE7ZNyAhRtkiFcf8c+y9vV0AxZukMHow13kaU/TR9SZm3hI6tSyq3a3UgMzcx9j5tVp08vvjoM0vAdAIgvFv+8EAPsAGAtAYtaPBrADQKw/4IFN+kqyxEsArHP8BAc7BEPGlJOJuJohDXHB1LZOPySjOHLSs9cC9HMGpSjCetZMTJRD4JDW9A9l4XACpJjJd401P7bozvGvxIOKG7Bwgwx7mlGMR/ct9TH6cNeGbfSReH3UzMybqAgD/FNLpQJliy0wM+9hAtb4p5XKSUJsE7IhjulSkKrxekIKSsmJgpSulsrA/wdA6knItYVUv5SIwkbSIFci8nxsXzllkLLaUkpbrpYlCnEBADmB0PGuaUMa4kWqDf1+SItw5MTnHoGic1nja1LCQFmxpgFEGKqBp5n4YQU6Q4H7QdMW9mDZotvHrYgXDjdg4QYZDGlIvGGOdw66mby4YW66QYY9bX0EZ+aMZtAl/rKysY0OkE3noThEZvbOnUean2pyPSH78hLH+VGc098CMNE5WZBSCk8BOMO5VviZ49cgJONtAFK3aYuTuqBpX/FfkJMGQxoalWEcIXeelvEYg5ETn30WSp3GzP9N/cYa/dFHb3v2Hn1ssSJ1NNv8xuK546WcartbPDK0e/A4H3SDDHuaUYwT+ma7GX24i0AZfSReHxI6HvQkP0rEb/unlolD5C5NrjA0cHg4UndVr8LKyiYdxGFxsfO3xiSH+wP40Pnb845/gvg0SHoC+UyahGYe6aQqaNpXTiMOACAJ84SMyEnDo05qA3PS0BGj1tFnf0iLcMTkZ+8kVpeAsAZM/wPpPIDEOWYv2Pzyornjr+wIHm7Awg0yGNKQeMPckXlp9GH00dz8SaStqJmRfSaRdTWB30gpK3u4uZBLZv5j2vSy11uYy5IfJxlAbAE/+ZuUXJCrCHFUl6SI/3MiIuqbJD1s2ldOHqREQ4eauZ7oEHzNP5zIidcR8eKRY9Sk5yQb5KVM8CmiMmYmEA1grWsV1DML7xz3QGfL0JHx43k2HhziGaejfdwgh5HBXZul0ceerY+aW3N+ojzq1zsld2Luy0xhaP142i3lUkupI01IhVw3iDNjNMKts5shDZ2AsBsMQby/pM7+/bO9tZfuY1A6NMqIuDegPETMOsIzF9/Veljl7iB0AxZukCFefXTCdNxpSDdg4QYZjD7ctVnvyfqouj09y7JTj+nENNJy2iCnDF3SDGnoBJh/aEbxp394Osdj+a6Q/AsEllwNoYhtP7F07sWNd2rtRskNWLhBhj3ZKLZ1chh9uGvDNvpwlz7aup66ur8hDZ2A+A91EZ5y3YsZfivYM5jed9OywlM7fPdlNsqdJ5cb5oWRwV0bhNGH0UcnbEGdOqQhDZ0ArxsMgdmw3WWMjD6MPpozNW6wFW6QwayPTtiIOmlIQxo6AVizCLtugzhz8nODJI8EQPlK81ZNkTcXz/n5Z7FqNfroOn3Es5yMPow+DIGKZ6W4s48hDZ2gF2MUu8YoSgps8tCUphkrNePxxXPGvdwohdFH1+gj3qVk9GH08WMiDSUFBZlS24dB+ysom0mvhqbl/YuLY0Mp410+3d7PkIZOUIExil1jFEdOnvcIAX2blu5uWhvD6KNr9BHvUjL6MPr4sZCGjeMuPB0aVxDIC3CJjqbkp3wihKDxaL/i4n+2sG6kAuV+Tg6Gxi5SK0JyM3zp5GqQBFCHOiGX4rQuuRsamzwvRa0kXXRCIysMaYjX0rWhnzGKXWAUCwvVqLr9XtYMbq50d2y4qNFHF+jDrI82IGD08WMgDRvHXjgKoCvB+p+11cGH9l6yJCTvXVJQkEJEV4H4NGj8qV9x8aJm8Bjm1IWILSb1CwD5AKSuxBMyFADJ83CEkz76EAClzliSyVdqT0gZbElDnbBmSEPCoHSXIRBp3LBZtiQDz+mdXmd7DmdbZ7HS6/xTt3zUlnLYBQVFVmCIflHeM7Z094iJ8+5UCsNiS3e7AQe366MTlkGLQxp9uMtWGH0kXh9bCgryQ4T7GfR+v6Ii2eR3aRvHFkyV0wBf2L4m+4UXNjfp0FwxKSECeQD+BED6D4rJFlngVLuURE8SNr/MqWApBayuSOT6NqQhkWg6Y5lFuPtFWDMr+1AFNYmZ0hp7MvBlTSXfnHdXWSBelYyYOO8xpZDXULpbL1VK7U+EEeZ6omUE3TA33SCDIXGJ3yjjXbct9XPDvEiUDBvHXlgA0KWoj/yi34svbm3unUvPPz8nkuT5M4P/0n/+ghfaQBruAXCHU8FSMvbK1YSQhFpnDDmlmAbglwDEKfzYJqmoO6QqQxo6BF/zDydq4nVUNDfI0VQGqeyW1Tv3UWbKiNZ1Z6xm4uMJlE7gf/inld0X73ufNXHecKUwubXS3W7AwWxSZpNqbl67YW66QYY9bX1sGnPhRIYa0q+oSKpPtthKxox5jKBX9ytacHeTTrLxPwJAKlM2FpMa7xSiauwrRapOAnAjgGynGJVcWdwMQMpoP+5UxJwJ4JV47Wpr/QxpaA2hdnxuFmHLG0TgtuzDoKzbAC5NnVZ2ufSsm5Ez1CZ1L4Or06aVSX34uFtjyOXuSncbfbhrwzb6MPrY0wlUyZgLJypgQH7Rgmt2Z8w2jrnwYYJak19UdFeTfuLI+B6Ag2IcGeV6IhOAXMte6vg2ND42CUDQ8XWQAlZSBEvqUsg4qQDOiyEfcdvX5joa0tAh+MxJQ2vwNd0gqmfknqaIrifgTf+00uhCidaVz8qdDwL7w2WjqbDjldhi5TKblNmk9vRNqrV1uLvPzfpI/Pr4dsyY0Ux8SbCqZmyjA2RTHTQ4RGIeEz/VzPWEbPgfOA6OckrQx/FZ+BkAue7Y4JTDXgXAB+BB5zRBiINcSwjBkCbRFqsBnOo805GpEn3WraRBSn/mAtjkvKH8/0AANQDKWnrroqIia+3atZFJkyZ163uZRdjyIqy5LfcgUiSOQSHL4om+UHhL0PKOBdE5RLzWP7Xs/zo8q5sMYPSReKPYER0ZfRh97Okkbvt552UEfEmPEvTb+fMX3N/c+0avMIgOD4fCVw1+6aXKZvpIyKWQgsYmpxZCDqTJyUHUEdxpTwL4DQDxcXgGwJsxn4n/wxrnuqIjS9fVpGEKgJ875T6FRb0G4BPnfmcGgHnNvbkhDTuj4gbj3FQGLoAVPCTvXsfz9zuBmRGM2Dwlo7Dsmw7PakMaWoTQjXMi0fqOdzyDRQNSbsDBLXIkEouSgoIzSeFqgN+orQo83FzIJbH+Y37R83KV0FKTCpa9nCuKpqWvZW8U3wU5XZAf1F3SuvUXeQtvKHGl4gn6qsOmxjlJLsS5Q+5mZFORcJTYRBbRoQxpcD9pEAm5MDut1qsmMOMgZqQQ8dthKzQ/Y8qOTqkHn0hD0JFV6QY5jAzfa9BgYUhD0/Wc6DmxvqDgJxbxr2OTOylQXwaHbabHBxYXS56FH1RzG2mQexshDBJzKscscg8jnp9CICSzlcgrrExOIZrGtRrS4MJf2B1ZhFyI5JCV3T8cUTvSbi2raEseh1goOiJDIlezG+QwMhjS0NkbZXvXzJ46Nzeef34We9UxJo10e2dGy8+J34IQhsuAqCOcOH8c5vz7VseTVEiDXE3I9cU3s2fPlqsKiUfdqRUUCOcw7YeMQFLpe0j96nmAG6KN7OQsBIZdDDu93w/5tYzsBgGDgMsRGDp0qNt+TLsKMTeBI3GpKwF86vgyCFBFAN5wriQaQ0jEt2E4gF2Oss31xM5zq6uZe+kfclP9qXY+wapsPBlojwyB23ofAeUpbHgb/rbBKZYsBu9IjZRdQYXRO7y4W3tkiHvwNnR0gxxGhu8VZrBowMINOLhFDrdg0Qaz0uVd3UQaGh0+wk6SCklMIZms5Irid86/hwBYCuDAmOxX34FmSEP3kAaem5saCNHVBJz4vQT8rcV856aL/vN1LHNfP3JkLys1+RwiNVBrSJW3N/sXF+9UyjowM+9hAP0U7Lkp0yre4sKMjIDH95AkgGKtp6XdXC7EMe7mFkPgBjmMDIY0NF04bpgThjTEbc66vaObSEMsGJIv+zEAp8tPTSdhhRTrkCZFOeQ0YpdmSEP3kIaamXl/oIbCKLucDJQXvHHxkH0PjM6zTePO7c/aexeI/LGSapsfH7BgQbSUNRfCE/TkvQhiHZuzITArdyqYhivCPSlTS//VlpVjjKLZKJubL26YF0YGMzfbYsvc0NetpKE5bHJaCy0xpKGbSMOMvPlE8Dd3MrDlzCdHDTzyzOg82zjmwlkgOpiZV1oaCzXRgVAYQYxwJBCcMHDRouiVU2BmnsQcZ2nYc9MbTxos38NElMZkT0+bWvFxWxaPGwyz+SXlrs3B6MPow61Esi22rTv6/pBIQ6v4GNLQ9aSBr4A3OCDvhZZOBraddt+o/seNoUJATRhT8DwBKp9RQMXF0Rrvm8ZcOJeJ9uOIntn/+eeXy9+qZ+YVqIY0qbv6NPhwJd0Yf1Ert2wObpHDDQTKDTIYfRjSYEhDq1tqsx0MaWgfbrt96sdmFHd3MrDlzL+MGnjkWcQFBdYmwotE0LGpVUvGFtxJwDBbY87A4uJ/R2lCIVSdlXeZJj5XHCAbyYP4SCRPL5fMZm1qPzZ97A4cN2DhBhkMaTCkwZCGNpnR7zob0tA+3AxpiEGg5tbc08mi65qeDGjmyNaRz5438JXTLSqEjlZ0I84D83IwLYw6uiqMkOcssq7tM2/eulhgTZ6GxE9ON2zYbpDBkAZDGgxpaJ99MaShfbgZ0tAEgcBteUfBwi/B6A8gg5lzFaGkLv+E03wb33maIvzwtpUnHEekJkiSLg2uJkY5FIFSt36QMfjzvkQ0FOCtdoTnpReWN60v325NtbRJrT3vvEE+n+cMZuRrJikCs0skR7u/tJkH3bBZGhnctVkafRh9JNLGdMVYhjR0AspuMATd9UsqOLPHcM0p0wnQTGbu2xoAACAASURBVNhRN/AnFyev+8fC4MZ99w3v6L2O2VIAZ4MpmRglKVmrnk/ut2UKAxJy+12zYf+5x7SKqYlQT3P6KBk9+hjlUfK9zvVHwzfFRnIk4rtjx3DDvDAymE2q6bx2w5zoLnvlViwSbXsSOZ4hDYlE0xnrx7wIA7Nyfw2mc5nwVurHpfesvfWjSK8nLnmnvjLvcCAS9KRVvRmqzFyqgxkngSgjY9h/hpAnksWEdRQJP0Me6zhmdTqY7XrPjuN7Tanb6cqiPepqTh8bxxY8AqBva5Ec7fm+lp5xw7wwMhjS4NaN0szNRFqbzhvLkIZOwNYNk7+7mHtgVs50sDrahr4j/ZPy5VsKro6ot99fF6lN75PUq7QiqeeWj0Goq/ri4Pl2KP2yjAPePYmUHfRXlu9FdyEgcgdn5bzOrA5ExL4ptbDiiY6qqKk+GFCbxha8DIZuLZKjo99tThp2RfDHvD7cuGEbfbiLSCbS5nTGWIY0dAKqP+ZFGJiRezmIztHMr4Hpn+F+x63QH20siwQyvJ7UsmdTcko/lc9D5fnBYNkgf8/9hTToYOrasn3oCVSLOipv6yfEYuBH9j5Pzq2ecO/iuy9e3xE17UIaWojk2DS24GYGjvKQnpk3ryH8M5HNDfPCyOCuDcLow+gjkTamK8YypKETUHaDIeiukwYuTO8d8Pjvk5TPluLa+uTsAnuz3hiq6K/sWv9bpGofTM7bfFe4utcQHfbVpg/+LIM82kPQH1rgB9ZH+l6X4ak6TDP4ltpr3imx84MMLFgyZ9zT7VVVsz4NMZEczPQykx6qSE1ommiqvd/Z3HNumBdGBrNJufG0o7vslVuxSKTdSfRYhjQkGlFTAAbVt+TmKC+uYOafsr/3iaqm4t3KVcd/yOwdBLJ9Hn/10UTar5LqdqTkrg7C8vQhRdpmCmtYyQxQeSTzqwdDFy38Wg/aVwIstG1PXzz34jZlgmxUbfM+DRcMJ1iTmzpCksZj+cXFUmF1l1Z9a96plocPZlAGM9bZkeCrPQurpH5GXM1s2A0wuQEHt8jhBizcIIPRR1wmxBWdDGnoBDWYRdgAat20HnsHh5z+pe/b/yyEtpcHS4f0hLZOt5Lqh1nJAXjSt34AUjVaRwYSWUOYFAU5xSbCxlQEVwNsP117/ruL7FNOZGDJotnjHmqPulrSx/chl6qfZt7iVWpZ3vz5K5r7jpoZub8jojNiP2NGkCKR61Nv3SKVOFttbpgXRobv1WSwMCSu6aJ1w5xo1ZB0cwdDGjpBAW6ZeG6Qo+Tff+PMZTe8CJA3CjWhDzHvLyWvmehORfSF1nwpiC6OsEUv1P9kdW/e8fCpvv9IUfv9vtW9+frgNALo3YWzx97RHnV1FIfaGbmDNdF9ADPAi5VSq2yNUSKfZv4kfXrZtHjk6qgc8XxHa32MDIY0uHWjNHOztdXrjs8NaegEPbhh8rvpuC/3meF9QOoAZXEGaz4USl0OUIl/WunRBHDo5p6jI76Uv4W0l35ec+cy1vzxWd8+M+uiYasWbLZ7D5kS+P0qW+GvS2aPn98edXVUH7W3ZZ+olTUR4OWp08pmigx8LXzB3FyRR6dOK7sgHrk6Kkc839FaHyODIQ2GNLS8StywPlpbw939uSENnaABt0w8N8jRVIaaGVlnkPL+hVgHmOgZtrF2lT3k/wZ6Nh8V5OTINYGbtzFTfRrVrJvk//O+NiyeEbz6WV+KZ0px4Zhokau2to7iUD0z+yQF60aQ/l/q1PIZ8v3bCzMykjy+p0GwnRLeujW5OipHa+PH87mRwZAGQxoMaYjHVrTUx5CGjqDXwrNuMMzdfdIgRacqkTeg8oLn1w564fho7QmRqW5GzlBN6glm3gsKm9aE+1vbdMawA5K+TqrXnsBz9aO+2aIzsw73rOgxzPNNZUSr5YdhxHgUFra6Kbekyo7qQ2S2Sd3bMD4/Tpq3QNEoBh1orifavoA6qo+2f2PzT7hBDiODIXGJms9dNY4hDZ2AtBsMQVeThpGT/9YLms4BqYFnJL2bXuBdvG8vVUOh/ONHRWtPEB70Tyv9n8gVnJlzA5M6gyPeQevtvCH18Kp+XFrv01QV8drrS1ROvg4lpeRW6TLamr0kEk6SPA3f1YU48w/PHpxM+uQzfW8es7/nK9++1roVaah7z2+XLm0kJ7FqbaqPaMVN4EwQH0yArcEr+hU9v1RSX28vzBuU5OUzAMoncKWt6ZP06aXLojJDnRo7btQRUkWuS526ZXM808gN88LIYDYpc9JgThrisVfmpKEjKLXxWTcY5q4kDT+94bn+Xq+6i4j9fags+XJf0YEepSkd1at7DT705JT1ry8EOIywfU1jpMG26w66WnPyb/6bNnBgZaRn/ckbK/6Z5K/q5/VX+7+ycmzf9owh3nr1Zc9IfVkj/FIX4sohBeRResJvkp8dlqe2pMlnitkeaH37uQ/1H6VESqc0JQ6x+igE1IQxF84hov1i1UpMK3vt/fqLnOKd/H057oYeRPyaf2rZ/VLNU3lwYGPIZcSqfSVjyo7t8U4PN8wLI4MhDYY0GNIQr81qrp85aegIei086wbD3JWkYeSk+bOI+GDNWDk15UHkqsqz3osc6Hmu/uzVs35+yPlDXzrtegZJPYmXUqeX/VlkKxl74bUE+unsvqflrfP1KlX1oXse3vjqUVVWyqnrk3oenowIp4drl/SpDzyhlToAxCMjUJjc7ywcmvJJ9oVJr/stRDYvDZ8UqNXJ/U/zLfftrdatZ7YfTJtesbS8oCAtrPiXAB1iH3DgBPp8xR8tjaW2YiLQb8UtgTQW2KSVAo2WOhhpfb9S3qxSzcBKS9sLtaIDADUySkxQd03KtMqEZqbshKnX6pBumJtukKEr18fulOIGLNwgg9FHq0vXNR0MaegEVfy4FmGhGjFpv+eJSPmTqeBJ7zWTpPbEA3XjN78dOabP9ecMG3XsP39yPENNAfF/U6eWzYqShjEX3kJERz6cc8x7n6T2O0r+1jtcw5mR4FHnbVuZxuDKf1l9Dip8srBSPts4Zsz0ak/Sz/6SdSSfkvl64GTv+2HNuHtM+RP/UalV84/zfpx5ne/JHcx6WeqnJ9+7kfiPRDRQntX7DRulVq9aGFU1c6UQBLb57v4LFixzxj4VxDckZ5cMSemz9mt/uKyAChF1umyspUHQd/inlb/bkenihnlhZDAnDeakwZw0dMSOGdLQEfTMSQOAQjVy8rAFACsd6DF2Qc4vJefCOf8IDVePh8fpG87ee9TR/xo5iYATdzppKCj4HSmcEdF46+pBF2yFhXP71FfvnWqHMsds+8yTF6n5UFduP3vvJUtCArPUhagk30+fzjmST+n1euAkIQ027vlp5cT/Zvry5w33fJR1Q/KT2xl4c+tHxy+xPGo2MyK25rn2Lbe8kzSj8AoidQ4x+jBhM9i+p1/RC/+KkoaCgtOgcL0vc9Ngf/6ar/1lZWPpfkS/NzAz72YAR5Himf6byjpUj8Js2A0Lxg04uEUON2DhBhmMPjphI+qkIQ1p6ARgf2yL8PvrCVo+XP33zYtSXptVhfR9qnVq7bD+PQelbn5nITNqUu3gtVRYvSW6UY+9YDhgTW348U87QqQ8ZUnpOel2KJwZDnwLpXqDeXlsXYjG64nDkj/NGZe8mDwc+fapuvNLq5G2/3lJr+ce6PnqS7meqPzsxBDIukEz/29A0YIZjfrYNKbgBWbdF0pVgHmrJv0gIsTKY10LcGZy7w06pc96JfkYWONlIh4KUhPEHyNs1U1oi/9Cc9PKDfPCyGBOGsxJgzlp6Mi250bS0A+AD4DcH0ecl+sRzSXY0BhAVXMvXVRUZK1duzYyaZL8sO2+5gbD3JXM/exJRQM07LlE5JfvPcHzXvaFSUuH9aYd2vL3yFDBbR9Zun5S8i3b/hGrlZIxY0YQ+FegqL5FsyGw/ZfUQV9kh8r7X6/ZSoLtqdKRpHL5WOpCXDn0AouAX/0m6blheZ6KqCMkmDlPVXydgcB/UuzSyd9+NvoQ9qjbwPR1flHRDd+sWaPV5Ml9vAqPseYwFH1NwLBYWZi5vGf/9+eGMmjuDqQOCLM32YId9lNtVS9UzU6dXtZsPYq2zDI3zAsjgyENhjQY0tAWu9W0b7durk2EEVmmADgPwDsALgJwBAD5Zfo5gA8cwrAWwE1yVd30ZQxp2BmRrtwgfnb945ker//sIdaGg69Jee70nlRVmYZgWWjAqWOSS5btEj3RKCmfcopnQ1bWAC+z3Wf9+m8D52+6PZqeOez1hitzciP1yX4CNthb+t6QV1z8mTwnIZceFTllVNLbw4d51vgGq29XZ1mV7/rDpUskcqKkoCCFFB4B0AvAf8Njxs30zJ//OBHnSZRE36KiKZvGXjgCjIMUEbPGWg28cuXACw7O9O64+UTrw77Z1lZ/DafWfxzZb+sX9pDnF80Zd39HFlpXkrjdydmVc6IlOdwgg9GHu8iT0UdHrUvXPe8m0pAKQOL4D3FOGMRh7jW5AnVIwtUOaWgRHUMauo80NH5zYFbur8F0LhPeSv249J5vbv8i0mf+Sddr7flJcMM+1aGqLC25EQD1YW119UONPgvyfGBW9llgSyIbttrgF+VvFuh8AFmNURHxLo2NBQWHgmgSiNMaHSHlNEGpcGH+vJdLmhtn5OR5jxDQF4wVGrREEaRGRjR6QoftaxbffbGJnohXAbvpZ0iDuzZsow936SMBS6xTh3ATaWh8Ufl1KBuFhOYNAeAB8GUMCqMALGoOFUMa3EAacqZL9IQNfUePaeXvikHKfvLIE+rKD3rark0L26HUr6JSagYxNrBt/zG8ffuGwcuW1dXMyruRGCcB/Gj5+8d+5vN5zrD8O07zpFYdzCr0Vu/7PhZCEXerOOec9LqkpCPsSy75l/XXvx7TD/iYioubT0VdWKhG1e33smZwMFR76bJ7fxmN2hg5+bnpBDqame9YNGe8iZ6IG/2WO5pNyl2blNGHu/SRgCXWqUO4kTT0ASCbwxUALpEfoACOBPAwAEnII/fie4tfw+zZs6UOwC4VBgsKCjoVNDN4ywikfP0ykr99B3W5R6F23wJAR5DyxuOgFWuhs/ugbsSloK1b4FmyGFRTA87oBfToAXv4cKSE3kXS1s8RTD0JvGo7WGuoum2wAqXQvp4IH3oy7OOO3y38m7fXomJHHSxF6NMrBZnpDe4SrTWtGU+8IYdawGWnDoHXo6L/vfTDb7GhIoCfHtYHg3IaXChMMwgYBPZcBIYOlQK7prWEgJvAyQYgO8JLjrBnAjgMwN1AQ8y84wz5TwATAHzT9KXMScPOiHTHLwguTO8d8PjvI1A6EX8VHPCT6/m/a1bbwR69yBO4jev8T4VDGY8o8EAG7wOlN4MlqzN0ap81HyT13jg8WDJ0n/rqrAjgIctTn6bBSRxO3sLa86UK29f0feGFXa4JCgqKrOBgPZkUhjeiIKcGDCx44IqjnorHEMRGgQDhl5m9Qy3FExgUBiITFs2+OO7sj80tuO7QR1M5jAzfI2KwaMDCDTi4RQ63YOFmyuIm0iBRE+LsKKcJYpyvjybiA8Qjvw7AXACNfaInDYY07H5qddcCqL4lN0d5cQUIR4X6nnAOf7Dx49D2vHo74r2PNH1Olp5DntABZIW9ST22l1Ny9fZQ6dBMlVRrpw3+vFck0LMPa5ZMjSE74rPZ9tTVb8upDYfSyxTx7/LnLdjlmmDkxOfOIUWXs8RYaP6f5I1goqMUgW48f/9RJx8jZSZ23yQKJK9+24OH1m4ekBGpS65V3vC6pIyqj/z5sxfdOd5ET7QGYJyfd9e8NASqeQUZfbiLSMa5jLqtW6uGtAsla4yeiGYMdE4S5ORBfBredPwb5O8XAIg6yRnS4E7S0CgVF2ZkrL9g4fakGXcdqZW3MFocytZbreTwOYD2KW84kJy97t/e9G3J1esOOgOwdOqAjz/lYK/DVHIwiTy6HqQ36UhSqV3nPyS0Na++fnvvi/svWLCk6ZuPnDz/9wQ+hTX+sujOcS/I5yMmzx+twL+48PiBo35x9rGtzvWS0aOPsT2em7d7UvrWk+W3wPVpdt3WdF3/fP78BSZ6IkHGwGxS7tqkjD7cpY8ELbNOG6ZVQ9pp39zywJKTQYjCtiZdxEGy1jl1aPZpcz2xMyxuMAaNMmwcM/oyQI1mZfdRxAeB2FaITMrbZ+ETVXX7vFa3pf+x5Anr1H6r39D1vtPBHrAVriHGars6cy289eeAyVNbOvDKPk8vfarkeqRk9c69SjPkNIGXhw/qO79uhN4Q6XPT4rvGRzM3jpw4/1RSfMOII/JH/bbgxFbn+saxBRKm2ZeZV1oaCxtrXshYLV2LtGV9uEkfbZE70X3dgIO8kxvkMDK4a8N2gz4Svd4SPV6rhjTRX9iZ4xnS4F7SIJJ9e8EFA61eFb/S4bSrtba26/rkt5LStg9g0OGkOMOXUVaV1Kv8bzqSdDkzPHYoqRZkobZkn7W+3t8OVr5abQf9v8vM/PCpWk/eXAb2aXzjcs7sW2H36vuX0Hkvrtrc+4bUvB59icNXg7DPmBMGjrp0VMNJw8YxF5yqyDqYmXpp5hJl1b8mIZgMqE1jC14GQ+czCiTKIlpCm/lJWHQkQf8LWr1ZX1HxskR6tGceu8EgGRnMJtV07rphThgS1x6L0j3PGNLQCbibRdiyYQ7c1vsIO9RzbqB0UL5d02uNJ6X6ULJsv7dnufJmlFbYwfIjPSn53xBxDzvk0zrii9RuHhL0ZW1OsVJqQgCP86TUWCD8hghfhMJ4IMXSVoisa0rsvucstw+qebH+zA2NEogT4y3jDjr/6EP3pxKn3kWsyhmwPVCzHpk//4PLxxQsAEEFq2rG/m3JkrCU0Fags6XAFZi/YkIlAWVejetyiotr2jp13DAvjAyGNBjS0PLKdcP6aKtd6er+hjR0AuJumXhukKOpDFyYnRaw1GMEpOmQt1rDe5zlrfWR0hqg9SCUE+MnTJQC27JDW/M26EiSlZRRkUfeuppI8pYjvbrneGI6ThHuSZlaGi06FZyZO5xBU1fYQ3fcFry2ioCeTFgL2E/cd/nwNamTJw+JKNwHljTktJiZV4F4FBHtB6ZN/YqKrto45sJZIDpYal5o5q0E+hUR8gAqYR15kJR1phAIxTS/b1HRX9s6ddyoj7a+QyL6uwEH88vWXeTJ6CMRK6trxjCkoRNw3hONYs2tudcrD5+gtcoi0msJdQ/7p1VJBs/dtuawqLql9z6W17oRoDwiHMgMAtsLCdSDiSRI+ggGPKytr7XtrSboiLIieSBdQYxrP+O9Lu5F1ae9Fz7oi2dDoxaHI3jtpV7XH8OEy+QawT+t/J5YoUSGlEmTTtIWTRRC0K9owUz5/KuzzvL5e6TNl3zk/eYXn7+5oKC/Jp6LhhoaQwmUqZk3KMbM/OLiVzaOGRMtoU3Mb+cXLbiztXf/7rSjEMkhK7v/5guWfDnogCMVNdRP6ZbmhrnpBhnMJmVIQ3ML0C1zs1uMQ5xfakhDnEC1pZtbJl4i5JCf5YEZOa8T0eEE0swcgdRrYGZoPTntloqndodNSzLIuDW35GZDh4ZRUvJvieCPZlUgJIH5UDCC0TBbS2UTYysxH66Jsm8K/u6rZIocMda3eF/Jw/CNHlC5w06vHelbtqNnNFsUP9a0uJTI4Js8+Tgo3NRY+VJkjtaoIMwjAvedX3wBIVq3IpNIn81Ml4Ao10N8T5/5C/4i/TcVFJzDCpdr5jcHFC24K545UTMj9wwiXAOQFco/fpRv078ftZjvTJ5e3pBJqotbIuZER0V2gwyGNBjSYEhD+1ayIQ3tw63Nv6474WtaHbKjxpkL4a+1cp+AIikiBs28hViXEsHDsPJAvDV1atkB7SENsc/sKOyR6fEkjyGiE5lRy8z9QcpW4E9I0VJtY38QRqyz+3hvCv4eNnnCE3xFW462Pt17B/fIrSNfuhd23RC1/lF/pGy2FK2KHV9wSJo8OUsRHmeCl8CPa03fKIXzGTiKgW/7zy++MvaZjWPGXAbiCxtLaFtQfZlxPoiylMaDfYuLl7amAPHfgPIUNvTjb0P9TrrCt/HthQzekRopu4IKo8SoS1tH54QIW1mYO8Sy8Csi2ksRhwF8mFJa9hDdj1A8L5MIGeL5ntb6uEEOI4O7yIsb9NHavO3uzw1p6AQNuGXidVSO4Mzc6zQwgYC9CFTKwGIAA4h0PZiOl1/6qdPL+u7uuL09MtQW9hpgW7650dOH7xrj1dqTVxbbIw+vZd+Hi+eMm1RbmDxoC+ePWsqnTFgVHrz9njumnd5cUbNGGUoKCs4nhV/FqlwcIaFxe//i4p2uWsoLCtLqFd0HsGQqjZECq/48v3hyYTNVVptOpcDMPEl93k/BnpsyreKttSs/5JwXRsipRTZrPS3t5vJPOmH67XbI9ugjdsDthXmDkjx8D0De2L+LU2pKuHRiU8LWnDAdlSFRmLlBDiODIQ2Jms9dNY4hDZ2AtBsMgbxWR+UIzMxbwOB9iSmPlP7EP7X8jJqZeU9ILgNifQSIwv5PyvpTsVStbL7FI4NcSgRn9T6MtBqkNe2Ah1fY4bqw5fGfTYRBChGttTr0PfuQvFfqTxuaRdvKrvc9cgWrlMsj8OavsfsfZsOy98HXV/S8pXSXYmaxMpSMHn0wPHSyYpUVG3LZnPRyfaEAuZLYi5jDzPR5fnHxErnGaG3acCE8QU/eiwDb/kjZBbKZihy5zx77ByJ1SqwTZ2tjJfLzePSxu+8LzMi5EqRGxUauREj9liT8leyHUqdW7JJ4q+l4HZUhUXi4QQ4jgyENiZrPXTWOIQ2dgLQbDEFHSQMXIinoyXse0JkADRVnA8D+M7MaSkSnM8Mi6M9Tp5efuDsIW8MiegXiyZsRm3MBkA0aD1W8MezfKfl677T9vp5GpP1r7Hz7iVDBkckIeX6VvMCTTsGaCu6VUcu+pDSqqx+oNn5A2p6YevMWSUf+XWtNhk6YAtEhAzPznpSy3l6ypydNrfj4m9Wfce6Cn8jfejPZ09OmVnzcWd/dERK3W9Iwq6GKqbZxT/otTuTKbTnHslI3MfidtGlls1t7p+7ShxvJixuwcIMMHbVXrc25eD93Cxbxytsd/Qxp6ATU3TLxOipHzYzcvxFRD4LuB6a+EtEAQiqJ56Dmbcyhs9JurmzxiF2OsmuPm7S253tzCsWZUWt+M+3mss8E8ppbcg5WXnUSQ49kRj5AIbkCIUIPufbQ9cmZtRv3hietsreVviM9GEpf+9mXQ859YP/zRo/2vfa7Qz2r+2yw88Jv1h+9w1Kar/LNC+aqLX4wHkidXtaYijyq3aY4RJM2AWeCWApS2Bq8ol/R80vjOUFobrpwAazgoXlnMvhgxWQzY4XfLl1a48kbrYBLAYRA/GVw8Kgp/m8WNfg0+HAl3VgmFVy7tHV0TgRn5V7LTD8l1n/xTy+PpuuumZVzKbEqaC5ypbmX66gMiQLMDXIYGbqf3LvhB0ai5nRXjNMW0iDpnX8KIAWAOD9Jk3TPYji63KGrOXBMRsidUemoQQrOzB3PoIucUYcALKcOXmbeHLHLzs0o3LXSaKMEwdtyj2GFKaH8E871bXpnYePfbfDjFjOB6Dea0YNID1OwUph5GwifCXlgrY7T4aT0qvLBwUB6fUp6UrWnbNvQSEm4//Y/ZQ2/+27/nWN8Knzox5F9ti0NnXT3cer9d8b4X/8tE50O0stTp5af25IhKASUJG2K5meIacS0sm9R0ZS2EgcuhAp48uZQQ6G17xoBK1M+Kb2p7uC8SzXxuXtK9ET9rOxDw2zNAHFEaXpFE+c3lK4nq7nIFUMadm/GO7pGE7FJuEGG5sh9It6trWO4BYu2yt2V/eMlDdKvGMDoZoTLaqZORFe+w3ffZUhDYklD1NdgRt5ZTPwzIuoH5u2a8UlgB57Iu2v3v5IDM3MfAahvzbCLR/X4/OmTtKIDADVSwioZdjZgDSTiCoCkYqmXGdVgXkwKb3Mk+Y8g2/NG4ISKoI+CB6hveiftSPFV7NiLi3oe/r8pve7aO8Oq7QXwZykbyk6mRxEMzsh5gEldCPB7qdPKzm6JNJSMvfAsAv1WKqmSxgKbtFTTHB1N2hRnVETs2IFZ2WeBLbnT387MC6S6JikazUwZzPaDadMrlvIelqehZmbeZQQeDVCM/eD/NBe5YkiDIQ3xbgZu2LDdIEO8eHVXv3hJQyqATwH8GcAzTslqkVmel5S9rTqGdcULGtKQWNLQXp3Jr++gJ+9lSHxmwbJzhu4zLDrPAnIfDhoJxl4M2kLgfzAwXgGpmjkE5jLFWGLr5GthMf0tdNbKDdyn6jLfSxlpYR6k65I9W5J9gcHJ61K9CFsECjLrSgVaqYlzANWH2J7nn15xXUukYdPYghsZOIltvrv/ggXLpF9j0iYwL+tXtODutrx3zay8G4lxkmbcnT69NDpe7ay8UzXjBma9LG16+XfjucEgJUqG2pkZAzX7DpL31RZ9k35T6cp4cUuUDPF+X0v93CCHkeF77RgsOjqju+b5eEmDXEP8A4B4zgtpcGUzpMElpEHu+A/JjZYvLxu99Owhww5rIA0z824G8wUg6g/mtX677OiAJ2cpMR0Cxb3AZAFUwWFvtg1SzwdHBF9Rx5Wdqt7fdgG/fYhXhRUn18KjtJ3KwRATpH90bM26XpFaDeZZzSV3GjpUEk0CjaQBbN/Tr+iFaArqjQUFp0HhetZ4p39xcauOfLEof0caYhwDq2fknqaIrmfgzbRppd8lgTJGsQE5N+DgFjncgIUbZDD6cOWW2qxQ8ZIGeVjKBl8BoAjADmc08W+Qo95qN7yyIQ3uIA0NBCH3MUkTHdj/56PSVjx9AhOyQWoCgTMZGKpAWzX4JoBHMtMZRDyQIGkm8SW0t3+oNj3l47ITVKXqYQ8KbdmUbu3oUeuPpIRzGMU4kQAAIABJREFUt6tt3KP2WPXRy6T4ZwyVTKCUqEMj67dTPy0f0TQENNYolowZPYJI/aYxaRMixMpjXRv119Ao6ldc3CZSHJiRN0KKZwHYCo0HoSIM9lwLQmbj9USjVtxgnI0M5pdtU1vthjlhSIMbdtD4ZGgLaXjQIQixI5ejwQFse3xf17m9DGlIPGmovKNnL4+dco7kSyBwpa3pk8Zj+N1ps6GAFCY3dYSEtl+Esn7DzIMsoq1aa68mK58UkmwmXcspAR+FwsH6VPuTshOzfSEPUlFbF/ZyeHWmf8v+/i/yt+se2071Lv8A0D5db9Uorx4OkmRDvFzIbeq0sldjZROjqH7/+8E+n+cMZvRj0IlgpECJAy9ngylZSIQFuq5PkyRPrc1YuYqptfJmM2FYbF9irEqxSyfHJjtyg3E2MhjSYEhDy6vaDeujNZvT3Z+3hTQ0yipZ+pREWnW38E2/35CGxJKG4MzM/qCku5hjMzPKhQC/5p9adn9r+v8u5HL5nFuJsMUiXuabWrYieFvO3azUZQxOqofXs83umdxbVcImhRqdZtfCpwEdCGh/+vLgEfbXPPCbjZRVPthbQqOT3jikB1XpAdjycbB0gNbhlJTk7I1Doeq9sPTXyhOalza97P/FyvbNv/7Fvj899DJDrjMaGjOGKDldIFQyk0T/lIKgtc2PD1iw4OXW3i3286gPh5U7ghUOioZcEj73h0uXNJfOuvGapC3jJ7KvG4yiG2Qwv2zdRZ6MPhK5yjt3rLaQht7RAkLALxyR3gPwSwCfd66I8Y9uSENiSUNgZu4sgA4m8AqCXqLZOkBqQMi3KNRdkzKtcn1r2mm6QTTUmUh5nBiZTKhaY/c/cZPOSTnSsyIpiexIqc7a+Hlkn6z9PGtSwvByJafX3hGccI1l29t7WHUnXJvyzKX9rc2pveyg1w6l7SjlnvR3HJtWprNUugpSGqrfeyVyzIjX7rr0uxwI6++ay9Z7/1tIwApiWqKB/QGeQkQ+tu0XFehZrdQBIB5JjHAkEJwwcNGihJ+euWGzNDK4a7M0+jD6aM2Guu3zeEmD9BMnSCEMz4s/GYD/Ex8yRA2w8WmIVawbDEFHmXv017M393kwrPpI6NJehZWVMmZwZt5cBvYj6Dv808rfbW1CN2LRmFDJ8leN8qZVnUzeus/vv/ej8dU3zdowUG1M/lXyC0pJOWzQvzbp3OEheNJ7UiBSrnsFCwP/txxSUBrAYGxInpb06NA0T13fskiv4J/CBaEA+QMpdqRXEoXTdtjp1WtV7hds4xUm/dmv5l789+G33BxRq1a9Gq4PXzr4pZcqGVCbxhSsBCFDsT2mb9ELb8nYG8eMmQ7iozmiZ/Z//nm56khoc8O8MDKYTarppHbDnOiovUrUQnULFol6n84YJ17S0BhyORXAPEeQw6S6HYCjALzfGcK1dUxz0pC4k4ZolkMnAiJs1V2WMWVH9Jd3cEbenXJ/b8Oe02Naxb9b05EswmeGDrUaEyqRpz7TSqobyrZVGQn6X71370MvGeQp8V7me9VWbNcy4+4P9IETy+2s9BO8729UQNmvawpfgvJmskZJOILX/rJx/oSUAV/+4q/Jp/nWc191qLWq9GR8WP9FcN/9i+yf2d/6egbBWEWEGqUjq+5P+fJGz+pVLwerasbuvWRJSAjMRsIXipAaDtsXDXqhIYpi09iCm6Xqpa0xZ2Bxcavv1tq7u9E4u8EoukEGs0m5izwZfbTVmnRf/46QBonRltwNRzjkofvewvlmQxoSRxpkpMYIiOj1REyJavlMWbg2ZUrputaULhtE0k2TRkQTKjFv9aTu+Lcvs/yK+sqsPnYobfPfMwf139LDm35O0utJ6aiu+UoP/uoze5+99rXW+Q6zPv8khUIrUqeV7VS2uqSg4Hc24Sd3DzjuYEoK2zcn3790Q8XBB1RV9dvnlZ4HhL5IyS3Vtv2Ksmg/IsqY6ft6VO/VnywE83IwSXbKY0GYLNcTxPqvNtNTTHqoIjVB3sci69o+8+a1+m6tvbshDc0jZEiDuzZsow936aOtdqWr+8dLGmIzQsr1hCR0uh6IphE+UPLZJFDwfgB8AOS+POKMK3kiBjrOl2UtfZchDYklDY0RENEUwTFNkjL5p5XdF4/OxSAl3zR5oiRUIqZH84uKXg3OzLkhtC13XN3W/EFVyZYuyjwg48ikz739VTlZNsOnbfaiPlDvwYb5kZHvvlt/+KeaIm8unvPzaN2KjWMvGM5aTb2n7ylHhknxWdtXlvo50j8C8j3Z+6gvdyT5N0PbM06p+ub41f68CWem1Rxw7BfvfsQSFgnUyRjiCAkgk0gyOaKaCBIJBGb6R/+iorjeLZ73j+3jBuNsZHDXBmH0YfTRVjvS3f3jJQ0iZy/HETL6awyAOELKf0cNeQKayDIFwHkA3gEgNQ/kFGMbgNcASGGkUwDMiLki2elrDWlILGmQ0SQCIsnLZ0BTP1K8Pd6Qy0ZJxChuLbz9tm89PX66Mjn7n2+mDXn+8W+Kq8ln/41Y7Re22N6Y1Cvto7RceJNrVI5VQSkUQlqdrreqeu54yX/kFyv9OdG8IJrx+OI546KRDSVjxox4IvvI+yuS0vomaRu5oSqs9udwuTddSMGXN5e89sq65Mzz3u0xeMCBqZHcs758+w0QskjjfSgawhJyCQ5CIZtYJYO4hMP2rH7OVUWj/B3JfNh0TZgNogERN+DgFjncgIUbZDD6SMAO2kVDxEMakpx00Y0iSUInea6xSFUoQbKK38T/ABzinDBIpUIhC1IQR3JB3AxA+sjphtQrqGr6vYY0JJ40dFS3C9/8kOe/+vG7mZHaoTYQrlWe0ksqPswbHNpOHmJrTWpaitIqxWdrCpFavzIzc9tqX/Yhngh5zqr4amNGJPzxtP4/+zsRRjAoDEQmLJp9cdS/4pwb//qAl/UFmlR9PVlBROtjwJOm69eeu31F6FN/395l3tTKnx3a56DjFz55V7RIFUNJaGU8tSdqZ+ZdppvUWGDid1PDZXOahlPGg5MbjLOR4XtNGSwMiXMjsY/HlnRnn9ZIQ7ITUilHuc21zkjuJCca5zt1LuR7JQulJOsRT32R93UAPwew2ZCG3U+d7jaKZ00pyj50QM/yz9ZvX7h/bWnfQXXbkoIqKeeYQEnP5Ei4Lju0/dUH9jvijAFVwZTzy74KKW/ttp7D3nvksbqxszbrnKQRW776MquGt0/J/1kxK2uMkEZt6+lL7rroVaBQjZi03/MgspgwB7buA9CFBD4mXdf3zI0EuI6sik1JPd658xdH/Crpht8l+3ukzQek7gXWtlZ7InBb7yOgPIUAS96F5QT2gOmohrTV/GjTBFLxLOLu1of5Nec+Um3mhCFx8dgON/VpjTSIL8FNAIQ8NNfkFKIwwYme+jiZJ4UsXOKEdt7qXIeIvBK9IdcY38yePVuuKqY1FaygoMBNGP9oZVlXVoPXPt6M9BQvxp8wAOrLL1D1ySpUf7MBZT2ycfCE0Xjmpb9D12lc+e1yeKwQko72oKikDzbaORiF5fBW56B47zEor65Hbb2N3J7JOHd4f/TP8uPxf3wdxfbnpwyG3+eBZsYzy9Zix8Zy7FNbjty8njhgxIlI8iggHIZ33nNQ27ZCZ/RC5IQTwEP3ij6v1qyB9c6/oQcMhH2K3IABKV8UI7nsPdQNOA21g86M/i255F9IWbsEoZzDEdxv3I9Wr+bFDQJ7MgLdnYDN7di2RhpE/qbXE03fKVHXE9kAjgfwkvMFYqklrHMLgLXOCYOQF/FtGN5c6mpzPeGuX1Jn3fjsyQcPzly2YsP2mxfNHi8ED+9cdNGhYavH0qDHV4/6LQe+P3jA4pSgOvC0bet6pFk1kVWZ/i/fsQ7aK4kjSZepRdqGt/YGffUzCiTXVpJgTObCukVzxl01YuK8x5RCHhgrbE0LQci2FE/oYdfh9g1L4IEGgR8P/d/1L/nuu/cWCadkzRYpslurPRGtyMnqaALP8k8r+6/I3li9EqT/lzq1PPo+bWnmV2UDWm7AwS1yuAELN8hg9NEWS9K9fVsjDV15PSFREx/E1LKQ6AxJVy2hb78DcCoQ9Xhf2lLEhiENHSMNZ05+bpACnQFQvmKuBPEn96+ev86p2ZBPRJW2zZ80lpRubeqeMenpAUcMzFm/YsOOF8H6rkh9YLVP+S785faPJvcO13gHhba9FvR6rIok/zgCJ32RmsVfePuEQUwHBb/VJ/Za5tvo7alvr7u8AkRbWfMsZamLmGH/qX7c+G8yTrthi866OMIW1tl9q9+2j9xiM+URsHL/YIU+OrBuv2MCJeW037BRavWqhQzYi1KGvraXvaMg1w7sm6RtSuFINbG9HZpX+Ej9Lqe4OJoePTAj7zeS/ZKBlamR0ltCvty+2qarGdgHxK+mTi17tLX3b/q5G4yzkeF7rRgsDIlz4xptq13p6v6tkYauvJ5ojJ4QB0hp4vAoJw8SYtmYjVL+Lr84JT/ELs2QhvaThhF/eO4Y8tAUiqnPsH+gNGPMtk975kWqd0oXTeDX8ucvaLX2hEhT9Np7/PQ/10huhO9aViSQ9Mvy9+r2Cm0VUgj2hHPWZ6qhn6Tl1KtAWmlWXX39Bm/GgcdmveWPKA/Prf1lgEnVM9ObROSxEFF/Tbuh3ALl1MKXUsnp2dU6LeWZunNSv+TBXwEUrbrqt+vTB4S2h6/e33eG5403fj0n/6R+ZUkZx/yi/H8H5kYC6Uk6IvMbqTq80WdHFucXF99IiDpJovaOvEHa5nubhpsCHK6P0A29ClvPUdFVBokLCpLKLH1YWKMfaar0eutX5D73SrOhyWajNKShq+ZlWzczMzfbilj39G+NNDSVakBMJIUdzerbkBXyuzz/CXiNHgDEmEuoZWzLcSI2WiyUZUhD+0nDyMnzHiGgr2asJM0LoejAq/4/e+8BZlV1tY+/a59zbpvehyn0XkTsYq9IEQVmBjSfmsQWE43Kp4CKkURUsCXW/I3GJEaEmQEVBSyxYIuKimKjt2kwvd259Zy9/s++zOAwDswMzDj353f38/iQzNln73XWbu9de631ln88L4b99tSAe0W8FciXzKMgmrkngtb1GS++2Cnuid/99dOxQtemEcvRDC5liDdeWzzr9ZJp0xJZiMTEpPfc6KspFlUdhFX3NF17+1h9c0qmVm6Umal1/wxM30jgUVBcERIbBmlFgUVRD6s5Vw3m5SBoKwLn3/KVOXJInYz+Zi+lPMIW6YLkDJXc6doLhkx5bNX2gTZdPnpu3ZbM0xp36pqUpe/ED/L4SO97ors4bpi/arOQeCKjsFBZskKlbkHaQE3Dr4losCC2LImdloVn4xeUK0Db5dITm2LprIuypTQWEJFaH6HCjKCAfDKzYIVyGj6g9IQMXVVEOMigZA4HOSIyREBcV9dPb9fvCmi4DsCTbQTuieiJw9ZJBDQc5gGxYIGY4hu+kkHS5aDcwgV5AcXP8MllV2/xQ0QXxI+6/MnHfq/CX1Gal/MAk8q0yPdlLlveae6Jjga1YWHqNA3i16reV9aI8wDFaFX3zf3+q2orOdnPTKcq/0Qwb7ze+dx/TzfW920dxTDvjrufC7B+/hjt+9W/uvvfoVwik+fkn0WCZ190YvaUl/9bdDppNOdX5evsJ3qK/SrR1FVpv3xTRDXkH+MuTb628pNaMK/NKlj+UGtZlR52XXxxX7sQvLmmpvSstWtbEo519Ek/et4TB0RpXt5iJh7JzI0C4iNAjmCifop4i7y+azJefVX5BO0vPSFDVxURDjJEQEN4zYnIeHR1FfVe/c6CBuXboAh8FLHP6c3hj8oEPKPZByHYe5/wQ88R0HB4oCE3t0BrGihfIkUN3RQ787XHJoX4GT62x20OaEbUk0lHX1rw8LWHxc/QlQPCfVfqUZZGZ75inr+wwkqUCd5dYwrEzARNwxmAuJnBSZaUi1fE/2+QGKdLCw/H3LU3JNfs2+/9/wC6eJz+7euX/WlJiIl18pylU0nQ1VOOz5ry8sdF43Vd3P4/lZ9Hn+re7Qb4qdyM8W8n2jOXndqwI/Wy6vVVLPFRdmHhohYtlk2f3o8N7U4G0kJ/Y/gZ8tnsghVrDme+d0UXnW2/dGbuy4ryW5f4fXph4U4GqDQv72EQD5aw/tQ3/0WVhC0CGtpRaE+MR2fHraVeRIbI3OzqnOnt+p0FDS2EVRcBGAZAhUUqq8NWAOc2e7T39rcgAhoODzSot1oiESTTp5C0ioQ8ueV6IiHQ9Hyi6TssfobD2RQnzcn/kAQPZqZvJPv/CrYdr2khGnb4WeasjJ4dC4KyfFVD4gkIk98OnLJorXnSaC8cW3Zzn/shoRHRNDCnX3hC5oSC/+zIcsY7HjuxcWfGlPotTpsV2P1O3JCGJs029OTG3fbB/uoiSBRkFRb+W/VTduGFLum0PwWieGaqB6Qgohj1TEgsyCgsVE67XSqHo4tDdcBnnqmXpqW8pBw8s/MLVSbVUCmdmXurStsNth7OKthHxhU5pH6sye4ejy5NhubKERkic/Nw5k1vvtNZ0GA0p3ZOArAYwIPNyZduAnB0cxhkb35HqO8IaDh80DBxzrKThMC81o6Qozx743Orf+wI2RV+hsPZFJUsBC4gQSrcd39hxodrFs/KUbTdXpG62JLGVBAlEAMmw/1kcJb3E2vc7igzIE5oKsqMtQLZTcIwvImprk1+24ZGYd/qg4i6vPbLoammO1o1rDGsONNTVq87zSdSTnon01tbc3XN58FoGTydgdH1wu4sccYHWAJ9ZbkRx16fM6Zumz1zW6Flel6NW9DQ1vfmoOvgYLpQh39RUlJfg9nq6hVIaV7O4+o6wmL5734FKwqKZl48SLCxGAS7JjG3T2Hh9xHQ0P6QHM7c7O5NLiJDBDR095zq6fY6CxqUHIrVcjmAcwCoX2MqC47iiFCWhhAJUG+XCGg4fNCg3mwJuRTgLDDVHhhyKbKIuLYrIZeqzcPdFM+9+dmBdsMxj4HBRKIWLD9Yff+lfwmBw1xo5/cf+bFweIeQsEIRECw1ywrYKv7qmfX4GbVlV/mFrpx0HQakZWjC/rmRVrclKsVXD9tb1Zr9s/PcO04c4q20BTRb9FZbUuonsf32DvJWx05q2DxYY5ZZvhpTELKDJOARNkvY/YhmnxABQY6Yqh1R2Vs3MsNDpnlz1B+ryjoz99vTheLQIPCv1SEfaqOLVyAlM6cNBWt3g8h1AMACtmdJ/C8VFiqH5f3lcMejM9/X2TrhIMORzM3Ofmdn6oWDLsJBhsh4dGa2hEedroCG1hIr1sO4diIcevWrIqDhyEBDTwxeT2xI1TeNvdNweX/Hkposn3MpWJJw+GcKjaO9Zf1L6/3Jnu/tqeN22xO8k+o2vevom5nbWLKn+F/Jx9n9wmj4yyPXK+4SnH9LwQAVUbHvrMarC4vfmOwnbeRuexxl+etS+gSaYiDAlkCVLaEY3JiczEEbeXRRPGDY2hcYNFoyb4i5s/xHWUnb02VbXRTPmHEi6SL07pFcgRTn5iYSyTwicZqKFpXgDUZtw7Ppb775o6imnhiPrs6bcJAhckiFF5CMjEdXV1Hv1e8saJiuSAYBfN6cxrm0WWRFJnVhe9kZe+OTIqDh/wZoqL1lzCrN5j/O3+halPLYVyHrQ93NR91DDu+VnuKhqLESKv6eemJqounZfEXF59P4+OOq8fnnb+UnHz2u2B4f/DpuZPbaBWeZk29depqKqFBhpqsXz7qtdGbuyiCENrv/RfKyys/OGuOtcNik6dFheoXTDb/pdAStqKi9WlTxmFH54wzL+RxLdgpBLzOrbJVcTBR80zW/prhToGFmzg0EOp+A9zMkHl5bWUlDU5NnM9FpxPR6ZkGBCkPt1hIOB3Y4yBA5pCKgoTNrtFsX38+ksc6ABhUG93cANwBQtMRFrb79AwBnN7NS9rpKIqDh/xZoCHqdTyX9ecNd6qurbxo323A2zWkqGUzuYFzxMyknqJwi+GXVF19Ex0df4K1tqFmVMNJRZsTWPfDo77NVEqdJc/NPF8S3KtBwwuJZt12dl7vcBGxzsyeL8xu3njbWs8eeEGzy2MiSwubhgDSMaiQ5ykXUzjFJjx2dmJS2FkBfgBSYbi5sQdI9UX/Ye0DUQnuHVHFezl1EdJxk64G+BS+qyCTszs09VROYC6Z1WQUFXU5V3dEiDIcDOxxkiICGCGiIgIaOdov2n3cEGlpCLdUvJ8UCpSwLyo9BZWX8LYBfHCyl8+GJc2RvRUDDzws0nPnbguioGKmiJtR8S2DIYhBe/7f3gROMqKbfSovcVsCxhC1sM5yBu0izopuKB9eY/qiiLc7k07519NGTgk3WMNQ7vUGY/4kdbKUF3XsvrP7mbE0Xv24i/ehd9sSji20Jda/HDnly3p53jpFCP3WXPUGTjPgh/qq4aCtAGll1jvhy+IOu+CYrFnXCtv6Yfm+8Q4RfguAHeJEEf68BMxliAkhRXuAtC1gTO79cAe1Q+dH1RG7ujSRwLjG9l8H8Z+V/UJyX93siPo8l3sguLHz8yFbEj98OhwM7HGSIgIYIaIiAhsPbXToCDYog6DsAKtRSkfYofoi5AOZgX+y6Ig+KRE+00f3/9U3x5JsLnPF2a6oADb7w+KyFL3+ye/LrUVtfx4IFoRTNnSn7ckdYjwiifj+qb/Hzz2PhbGEED3jGlqj3lwy4KWhG32QxTqzXna563SGh6favjRS3BouPrS/azYYhJZHDkJY3AOEi4mRJQpbpMfUD/dXpGln2eHgYQV1Tzg6WEBBCgshE0O6xkvpues/QfQ4QBgH8ctT8ius8CxOzmY3HQXRiKCdjs/WBIJ91za94qb1DqmTm9JMA7Q71TPk0EFCp8iuE/r8pF2avWKFyo3RrCYe5GQ4yREBDBDREQMPhbS0dgYaW/Az3AXimTRdnAFDm2eObfR0OT4JufCtiaThQmb2xOe+zDliPtKQ1HtU3fsp3RXWr1BXAGuem2zoLHCbMfWGUQWIRA16L5aMa8XfEIgdEUyWjZvWOWb+uyRj7BzKsEzUQm5a2WfPV/DH+r0W1RTk5s4SG2yDJZwLFtceePMNY9+nvfM6oGzRYGQ3C6as0otyvxw3deXb9tqzjvKVJmmR7QIdwcjBKkxY0EWBpOQghowHBgrAEsdQpUB/bf8M/yekOQIgTGLQ+ev7euU13p90LorEMmUGgUpWEShPajQAL0/RepUIzeyJ6IgQwANozc/o4SK2fBdQ4/P71Ka+8EuLfaFt6Y06EowwR0BABDeG6PrrxSOyRpjoCDYpQ6G0AxzYzTb4GIADgBAD/av7fIwG0u0H1iMSHaDQCGnofNEyas/QyIShPOcey5OVXTRiy8pk3tz6vOCAk5BNrFl26n9vhUPNj8pwlZ5HQZjNo7epFM0OpnZUFI9EulzJDRO0Q0woL8w4IJ2xpb3du7rGawAKVWtkMmL+VDz1U++Xdj09NZu/T8UGvSwpt50Yj6Z877YnHntm0Y4JDmma66a7QbJ5RYBIqnTZLaoDUYxmsaUZACgq8EfDFDhWkRQvJL6aPemO+R3cqIK0D1hqCNlMC6QTa1hJR4VmYfgsDZ1iwFsfOr/zwoHkaBg+2l4wZc5KQMuj57rsvhmzb1mm6+VASKpdD+T4M3a9PJjdb1n3ZK1b8iNgtAhrC67CMjEdkPH7qc/JI++sINKj2Vby7uprYT4jTqtMJAEKcBOFQIqAhDEDD3GXzBCl2Un5o1aJL1qpN8fdPfX624oBoDQA6mi8T5y0dp4H+xIxtVyyedcv43NwLiu1x4/+eesK0ALSKfz185dktjJRt26rIzY0OED0N4mh1uyBPO+Mi90efvF9pix5ms4IN2YGGWmU/sJjg14yxEsQuy/eF4fSNJ93Lljv+HWYxDkRSdzTGkS2oO+L3vNBUNLyISb+SmL/IKCicvJ8vI3QbgeMAImZ8RsK8xnVH1V7vPWl/ZqZBLOX86D9UbOgJS0PJzJybADqnhXuCgZEgVk6gtcHyymsGrF17QA6VyCEVOaQilp+D7z7hsD462ht7+3lnQIOSUSWOUWlqVRy4ytGg0kfnN0dSqP+vMkb2eoKnCGgIA9Awb9mtAjidpfXw6vt/8a5ahNc//ek5GsTNkvHRmsWz9nM7HGryK6tCkl0+pRwgT2zcFZ/tr4va4kxNatLs9iGeyqppdd+vzigoUFTe7fpJqKRHzMatRJwuh4+Y4t6y87+fRGcnQGLXBPe2Y5QXgWS4A6T1FyzJBq4UjsY0hoT0xdQAIgbMLIyApjl8QiSUFviLRm4nQVdJyV9mFxZOVPIrvgzW6QxBmBVaJ8TbwMo6R8kAnUjEddVV5ddk/xnensjTUJyXu5wI9hbuCSVTSV7OsyBKAcz5WfkvbWit53DYFMNBBqWTcJAjIkMExPU2COhq/50FDYdqd3QzcdUfu9p5d9ePgIbeBw0X3Lpkkq5p1zGo2gryE3NzR6574KXvnxOERCm5YM39l4S4HTpTJt1acHSy1fiXBOkbbkEE6zX7nhjLWza77AOPg6yYtlTWbdtUv//Lp01L8cydW/7Qvz8fvTsmedGUmm/7n964M84pzWCN7kSMFcg02BI6y2rN8KSwZVcgmCVTkJgMgImEBc3u/U/QGz1QXU9Ylny57/Llv2ndX82ChL523XYX0IqiGtxoEC+y31ERuib4EWg4wjwNB+OeKM7Lm0vEpwqL789YvlyFRe8vkUMqoouIpSFiaejM/nuwOt0BGkYAmNrMSXEkshzxuxHQ0HnQoFJGa5JvZ9IGkeRqiwLLXr//8hePeBAWLBCTPMMXCQE1L9DiCMnMFU2N2o1rn8xzt+1j8rwlCZA0lUH9CVzPBIfTDDiHBGtHnFe7aWhAs8Vt0xPeXZUw8vE3Hpj1ZUle3plEcnZNmtu2J0H5AQpqgm3jporgHz+M/Z/xiYHGE85N/uPwAAAgAElEQVR27xg1wF8b089X6xHjxl0s1q+/6rbs8/tdUL89L8usi//MmVkS0A3raHdp2nBvpd8BGcewEohgY2FBN7zS9EcJcCiAAkFoXpUcUpOWV3e6PzCiGlhP2LNDc3m+iHaVv0Kz4eUFsHltaeMgOYuEqHLXmetT7q/a7+/zI9BwyDwN/GlWwfKFBxuPC2554ShdiNNvKn//8kTTa/MynjrlhX/8tTX3hEPiN8mFhS2J2EJNRUBDBDREQEMENBzJPh8BDUeivYO8Gw4b86EOiAk3LzlBM/TlJPgAQijJ/PfXFl8SCgE8oqKAQ9PwSUKjMVOOz7x35WfFs+r82isf/znP27bd82cvzTYM8SARh7gTmDFCgOMSTI+RYPl8J7t3uwb6qrW0QP0GnbA0M3/5Y7tnXHQu+u8tNJ0Bvd7m2J8quVLG2VY2TvxmetWWwQabUQJw6FLKDJvl1Joav2Vg+xZbUlOs9I/daUssW5J8bAE11r/1WNVbt2sajWemZKZgwJFcIpn1+PU8TEuvlzanNBEQelCXUui6Fy7hDxBJi4QMuNKKtmrRNVtdpryRFlT+CBAd6ld+8aHzNLycXViokqr9qEyck3+xJvhK9aCvvyZqes13w5S1JC3o3hot/fWhF5j+nVVQUBCOB0S4r48jmvtdfDkcdBEOMkQAbRcnTi9Wj4CGHlB+uC/CH6ineRck/k3KcVGQyuxpWeBTXl90ya7uUktHupg8N/8eIj5KhWSy5EohxOVO6e8fZ/mtMe7ST6TQko/zlAxLCHr88dK7kQLW/Z50993R8eUjajRX7RbR5+8qmVISGn+lCysRtfHumIqYIj+0tHXR/XQnB4PHOb2ZiXuLt4F5N0iUMKRN0VwfwPfA5AY4SrWlMjReOyAvKpqDN1xV/umQjGB9g11aCTrMDM0IaCDLoweNJnVzobvqGqMHfrdZkMx33lHx/KH01lYXB83TwOQWmnZDxtKlVW3bm3DzM4m6PeYZZtYF0Rqlt5Sge9pJ7t3nDPVVOob6KpcYpK1Iz8//tj1ZOhqP7hr3rujhp+gzoouDazkc5kQENPTWKuh6vxHQ0HWddfhGeC/CXG3S3OnFBEFByz/4zQcvD/1SnzQ3fx0R95UBvv21hy95tsOP7GSFQ+tigZg0d/gKIhIuB+U2+eSNyolyTFPZmCbN5tirRed5oSVeVrfhwUG+6vh0s8lk8LZgn71DRJQ7eh0G3JF7z4sh7olH7vzdW6PEtlPtDQ5/n1LHNy7Iujdih/hXJB9lm2vbNaX/pi/eIIKKpqgyAuY1pqFdA9DxRMojEp8JXX+KpfkrBk5X7RUZ8VkGW/0SLK/HCAYaNV0kW5plBGO8xh5K+HpAdaCEhDgNIuiLG/bJd4HKfrWequyNxByU4G+zCla83tZJs6PoCQKsFlnaAwxKrslzl44notsk06drFs8MXV+o6x2C9hwzrFXOa37dqNlSYqyqYloAT8TSEN6HZTjsFeEgQwQ0dHJDDYNq3QEalCNkDoAFvf09EZ+GA0egvc3g2GOfMtLOjQ0RKknCSS1WhUlzln5KgvpJ8O2vLfrpQMPkeSOWq1/NRNYVYHEdEZ083Lt3bIB0m9eS/1MSlSx1STdfWvNFxmmNu1wEfqtsQN2JutPTd6fMeGr6H1fcNfGGNfas6K1fRZFvqB4UlhVwNPb311bag75Nq1KO0m6175oyaOMXawQh2mLU/L2gcMYCQNZefHG8jPLLpCWvNSh97L3s/KigP/56kMwJkDHcAhkauN5uBWpAYoCpm76aYXt86wMjVp+3peYhjWzvMFmGHlXTBCuq0fK5drSMADF93za646B5Gs48Uy9KSuob7fBUtchysLXUmi9jzeJZKjsrzrzpH/EJNnr+F85VAyYaH+6XgQnvRwX3PtEaPITDAREOMkQOqR9mWGQ8wk8XvX2WHqr/zoKGFg4KlWTnuTYNKm9z9fxHNLw/9YdHQEPHoEHVmDhn2SYhEA9JOyxpLtOEOKm3ryfA+NayYJHAhCgODo2zvNY59VteWx0/MoGIUy6u+d46yV1UZjZ5rvzsGMcNA42y3/rY5t4rk5e8ETh1iAFrukGm4fTJgFvGBYjZTiyDR3nL60+K9mfGle7eKBlFJPB5Vn7hQamsFc20xtZzdYZr+HpnhrnVnrxzRsO38fGm71iGJE96vcfuqP/eVR6/w/TGTCIh7cLe1CCDxjdsOh8hQGPGNBAltY3u6I7NeeKtywZpGv4iWV2OYBUzbRLgiZfaV049Wt9s9BOl3wMoByhDjTVBvuuaX/Fwy8zoDhmOdF2HgwwR0BB+B2U4zItwkOFI11dPv99Z0KDqKfKcC5qzQe5zttpXzG4Wsg+AOADK67vF8zw2tP/tK8qZPfTLsG2JgIbOgYYL5iy9UiNaGCJWalWklM+8dv+lBz1QD2ecO1qEF84t6CthPUBELsnQQBitMTtTgm4RIwNBj9BtOkurn6+mxkvGa5/YE/90ZclV9SkjzvskTriH1Flx+qvmmY4o8lijxebaL+tP2jrCWzHyi6isODtblFezwXQJadusJ9TutiXs/caV+sjOGtu/1v7zVwfkFVF5IQbo9bm/2rv+twODdaMkyLPHiA7UaU65yZFcmVP77ViNpQabGTDYMpmFgISALSilLuXeWG1neRx9Xm86/nrmNu7DoKvAvDarYHkom+WRHFIledPPEqQdxUwJkrl4cZ/T++1ypYxrabcP7Um42vHiKEXN/ZR3xtJypH9cGHszS4lbmNkdfWf5JUcqw+GM/cHe6WhOdGdfh2orHOSIyPDDCEV08VPN/CPrp7OgQfWiEu1c06a7CgDDVfa5IxNj/9sq/fBjANSd+jxAZdkLEWap/75oBgyKJOt2ZV2PgIZDa/1Qi/DcuS+capB2lQbZny2qkDq98Np9M1/upnHc30xnNoKQc5/hulCFXILRwAJaNAfjXWZgkiSRarBV69bs1R7N1sjMnqGNe+64seqj20rScOoOZ0LqZzTSlRWsqc8p2fjqHRmTX0uW3uMDun6tUwad4+t3m0UxKa495GiwSPOVGzGbG4VtS1OjuKkl/LOFL2N6zTcnjfZVpCcEPVGNwvC7dUd9jOWv9pFN9AnUDdaZbYLYywSDSNkdLM2K8rJkG3vi3d5AnM8vJdgszcrPasAglvgou7BwfzKrzuiirf5bIixa/11luVwdO/zNVYmjDGYedazx/RkX2d5O2GL1q1oSuGi7qquz/60lMXPOUVkqXebeabRgH7g/HBl6Y050d5/ttRfRxZGB2e4eo8h4dLdGe6a9roAGRYWtKIpbO1epMLlbuol7QpFjqZC1JAA1AM4FoEDEn5pBwu+aQcNBNRGxNByomv+XF+H5txQMsOnyUWWGb4kSUGZ4ZYkY6q2Us/e+r3hRat9yDfry7cShl6QFGhKurVy3NUqaLzydcEx9jTPmaTcZdhaiqH/f5KP6fbeu0C6D/T9z9Y3b7ErZwkz5qxfPDEU7tPBlzC57b3Sq2VRLljRqbFFxm53J9cc1FlvJ0htDzMr6JQHaYikSLQ0x7PAdrQxfprRXsaSSxmRPnFN40436GLga7R9CoiCrsHB/Mquujsfe3NwBpsCj4BAn1RoJ83uNtIkMjAZTaVZBwW8mz1v21BixecTl9pV9ooRn1x/d171WQWlnHa9/nfg7xxKvg/3V0XfunRmxNPx42+jqePTEFhyRIWJp6Il51ZNtdgU0KDlUXL/iolD+C+qKoN1rgiMQWPFbKOuFkusRALsBvAJgS6s2pwBY3V4fEdAQHqBBZVsqzc2dKATGBCdccJ94fc3k9qIJDjVPJt+69DTSaE57UQIZgfoBfyh9aydb/NBlqXmfR8XIpxMtz6AsX126FNhWbEvUUsymYV7Smsrs8d9fdf6QKeMe+kOiFu167oPo/ilLUo6tBNMHqxbPvD8EGuYum2eweerdJf9JjTc9dUJaW326/SKPZot1BIOWk4JMDIuk/Hvm8hXKAoZVt067ZWSNuTBo6Q0ur/5PAkZYBKcV5TtVUVHY3PYldqYbUwsL9+du6OoBUZaTc5rUaA74h0RPuydPTlDfoawNf88vnP75vGUrXfCIp1x3em3CsgNsfWMN72+jQHo6VW6LJffL0fP3PhgBDRHQcLD11tV5eQT7+yFfDQc5wkGGntJvd7XbFdCg7lDXN3f8ewDHAFBOVw90lzDN7ShQoszkysP/F1C/qvZdU/y1+SrkPwCGKMCyaNEixe73ozv43NzcbhYp0lxnNaAu0o03XgdVVh7wCqekwpwwARDKQNBx2banEe98vRf9UqIw4ZiQTx8CpoV/vbMToroK1wQ3g084AXL4CFTU+/D2B1vgLq8CnC6w04nBtUUIuKJRlJCF8SNSMLpPFIxlS/G1FYMP0kdhQHoMzjtauc8Ab35Zhl0VTbh8x7uIq62ETEyA288INjQiLtAEoQkgOgbcvx/MnH1zq/Kb95Gy5hVI3Qlx410Q27ZClhTB3Pw6TBvDdvkiCLvyDz78Qjt3QP/gA8iUFFgTJ+1ryOuFUVgAEgK+WZfimbf3BUv88lgNKTsKIHw1IX14AxZs2cfCMe4SwHAevhCRNyMa+D+mgUGDBnXlXPw/pp0fnAs7+nBFSPVRc6USAGuarQ7qvnZU8wHfURudeX4WgHcAtLYmKOuGouNWRQ2meq6y4e0PLWtpOGJpOFDFvYGai2fmTCSQusqqJYnl/ssuW2l7/rnnQRTfEVdEa+lbogTU3yTjGcDcQdCnEeH4NH+99seytywwV4OwXJq8FxrdUKe70nfaEt6K8detGSo9i96IGZb5UVx/rf+AtKMyv/lkSZQVGNpyPdGaB2PynPwrSHDO3JK3j84KNkRbIF+ZLTaQEmxKiZYBNfctArtBZDLzfy1f4G5vnP33dpvvElO35NZ0bUWD6ViVoruvSdTqRnkte80pf1yrKOMPKF0dj1BKaBh/CV1PCKwSkjYxceh6goGy7PzCayfNWfa0EEgPRZ/4zVXDbUWDTV2/Yo+V7HOT87cqpLZuQdpATcOviWiwf8CEmc5dr8927i1/kh5Dpym4O7N4O1unq3robLtdrRcOckRk+GHUIrro6gzunfqdRVTK30CR7swAkAZgcLOzovJvOLmZOvtIv0D9LFMOj5c2Oz0qfwkFFm5tZtBUFo2s5mchS0PbDiOg4cgOqSMdQPV+6czcW1WCJHV1kL18eYga237bbWeDeHbbaIKO+ps0d9lsQVBAcn9RCYx0K3Dfo8Wvzng/ZuBFpUZcAgtCctDtPqVh10fJVuA6dSVQMjN3dhPZzv1X8jGjszV/dqK7xk1EvEeLKV0b3e/TWq/z+taOkNHR5qO3lL8/yW4F9Sojxt0n0BAXb/nshjTZT1ogIIQnygzGGCH3glBUT6XXafax0vc6HVG1hgMBXZDJoeeQVU74v/Cz9nbcH8pDyadUOZxNUX2HW9inujVbkkXCZkjLG2N5yx2WdWd2YeG6iXOWnSQE5qlQz9Z6kpL/s+b+Sx6tXZDe36bzw4Ai3wL8madMsZd+tIoIm53BvXNoQfssoR2NzZE8Pxw9HEl/B3s3HOSIyBABDT0xt3uyzc6ChpY8DYoSe4/aewCoFLc3N18fHGiLPjyJM5uvP5RfQ0u5HsBKAO8BGNj8x+kAXmqviwho6H3QUJKXdzuITwZbD2cVvBiixrbPm3cOBG6WzO/1LVi+/369M9PkgjlLz9GJRoM4gSWKgybefPPhF8umzJ3+cazlH+KQQT10GArNahCOiooanPbpM5eWq7/tvuiic6XdNr8pIfUMb5N3r3K0NVg2JJjer51S3pBSWNi0Z+b0cZBavwoWTcLmuMdDWvQTqScV/LJy/Zhk6T3FIc1YApNXaMFYK+gkMDSWtQSUCkdTrJa1O83mqrdrKsUES0FqRalKymmS2auB33DMr1TJzw4LNCieiRM8xXOzA3UxLmka1ZrT+5UrvbzUHjf/9UWzPlPtKvIxATpXgLPAVAviDasWXbJWPWu6O/VakJjCwCaN+cnyCwt2JK+a+TABQ0HWk1F3VL7WmXHozjrhcFAe7nh0px4iMvT+ftV2PMNlbnb3POvO9joLGlSfpwD4sE3nig5b/ac2yZ4uCepGt9nq0G5fEdDQ+4uwJC/vChDnqKsDSfIJ87c3rrM9+cRzACd25XriUJNp4pyldwpBvwOjSbJcCiIi0EyVJhosXly9OE9dj6DlqsQad8wU7csvLmydeIlM+RLrQl2tDW3piyUGEqGSCB9Xk/NMFweOI7BFjCbVgQWKIkDUafYNfaj6M83h+6XQ/eTK3lIFlgkQIuQ8oMgrGGQCrJFAkJlXA5rwDJo6w7595cWx88sVEO6wtMcz0RJBwozS1YtnHUDP3V6DTfek3gkWJ5Dkha4/lH+qNsU+S8efzKA7GPxR9Pzy/SGhHQrUTRXCZWMOBzkiMvwwqSK66KYF1sPNdAU0KFGSAYwHoEydyglyYw/L16XmI6Ch90FDRW5udEDQowCnKGnk8BFTxKaNqxjY+Pf8wnkqfXOXBrWdypPmLl1FRMdBykWr7780ZP6fOHfpPYLoSkj6YvX9Myerv7VclQQvu2LKgClTQnO9dGbORfsSL0kGCWLmRkH4EIyRTDQckgeD6Dsfaaca4GjJskmY1j+Fro0OCm2UCRFXqUdtHNlvzb8C5SMWMbMZ0//rd0HiPJUTASzdTEQa+FPJdBYIBgNbCLRt/9UA5LOu+RXtWstaf24Lz8SpDdsrLq/+6muLOb5Rt1UszDjvonrN6Vu9eNa0jgC75560G5jpfGL5D9edFS+GQMMLp+Qy4Yq22SKPdFw6+344HA5K1nCQIyJDBDR0dt2ES72ugAYV1aASPJ3XLLwKjbwQwLpw+ZgIaOh90KAkKM7NdQpgKgsMti6YuFBb89qUzMLC19oSOB3uvJk0d+kbRDRWEp567b5Zd6l2Jt32wmxiMYclf7bm/kvUvETLVUnw8iumDJjcDBpyc5VcV0vJ/YSg3XrAvDL9pZcqlKdCaV7ewwweQbA+rNGjr462AhkWoczJZglBDAow9KDQo3fq8Z+eNGTFy97i0fcBLKOzv36HNO189X0Msx6s6yD6L8BqrRiAfN1lBn9RfMGztUlv/XYFwMI0vVfFLWhQ+UgOWhTPxLSab54c7St3ZAfqQgDdJE3fak88aknyuG/+GVM6CQsWHBKEBe5JOTrI2t0gNoWkV2pPuv3ZuHX3vAwmHcxPR91ZrkKaf9ISDgdlBDSE12EdGY+fdAkeUWedBQ2qXmGzI+QK5QQGQJlGuzsj5BF9TAQ0hAdoaC1FTxwQk+fk/w2CpzLDzQJLpMXbNNBdJBANyMdWL7r0nmbQELoq+dH1BCgZhGRmlGUXFCofmVApycu7E8QnCIvv/ywq69okq2mCDg5GSX9JlBUYpK4nPJoRbCTHmkF6kUcY1iXC7mZnn53VBKSDIMBSkiQPESokkQLaCHLTefF3ut/ZdzVwinIUPcOCtTh2fuWHCmAR0W8Y8nhBpFI87LRM+Wy/FSt2/O1Xd54xVFbmK6NIlRH9loeMTxKl79IY6RtYpbnKcp59WIU9d1jcC9OvIPAMZQlpsXYA/LHLLF8UcYTs3fC6nlgfHU6INhXCQYYIaOjqqPVe/c6CBhU9oSwKSwDc2yyuyp/wDYDjAXzee5/wQ88R0NCzoEHxM8TbrakCNFhFMTDxTu9e38q2PA49DRpOvOqFtKQk+oCIFCfJ/mKYZtGju15+WGg0SKgwSYvLggLnYMTIy9UVSagihzKOepk5hYik5OBTgrFFaMaFUvIEn9D5X6nHrRBSZp3euOtiAjhIwpNiNkVHW36Hatchg+tBqDNctcdsT9Bji20pzr72YpGh7aVY0QQbAurwV34+Ktt0PXt5ePS9FeXbt23jPvmnPMJMg1jK+Q/+oeKbq2bmqqig/X4VSkRiBNm0fi+EGFBij/3/NjtTtPzkccoJGTFBr/Gbyk/Hpgbdm0Ysff6AyJJDrUHvwvh+ku1jas944NW4D+eMirl9r7pe3F/a8lsILfBm5rKVITbU7i6RQ+oHjYaDLsJBhgho6O5V1nPtdRY0qHqKD0Jlt7tJxa03X1OoNLzdyT1xRF8aAQ09Bxpa+BmIqHV0C5hR3prHoe0A9tSGNOa6JQlZcXQXkTaSLARjzKYN95esSRdEIV+KlkJAVWBG7i+NFYXzSfIJTJQO5goikQFCJjOr0N4gEQXdpBvvxQ4S30al+yr0mK0jPXsdJ7qLhthh+qOsYE100GfFwPdfZioj8K6lCWNnlDtjztLIMuyaRz/BuV5k62XUhypltPAGGDLAEKru+yzxnnvs1UtivnlmFRHXVVeVX4PSvLOI+DowbQ4GAo9rdmgChnLiHAqJVyVZmwRpt+7WY5vuyzrvYxVBkuJvqJpf+u5UB1mejPzC6V298mlvPA7Gb6FD3NMnPz8UodGdpafmRFdlDAc5IjJEAFRX521v1+8saFBytiasUtcSBxwe4WBxiICGngMNE+cuu1wjqHSItSx5uXL2I6JpBE5qzePwU4GGtv2UzMy5HKDcloRPrSMlzNyZUxz5+QNDPA6qEF4VAWuT1LU5BD5LmQUk0dvPpp0UvVePzs4K1NKopvJvn0k78Q2d5eTUQIPz+Pqdd16989N1tHZtiPjp0av+dNr26KRCZok00/v28c5P+m20ho8s51h7KlXXXpP4rz+TEOcw8zAAOxnkVVcDttIPlxrEi+x3VHzdNjxVtVsyc/pJgHaHyn0iEVzWUXKnrm4gbQ+pzvBbdLWPjuqHw0EZ+WUbXod1ZDw6WjXh87wroGF2MzBooatu/RXpANRGp64req1EQEPPgYYp8/JvA3g8wA+15ACYNHfZRYJwVWseh14DDXk5t4FoPDH9LbOg4FUlR0ukhHXBxCnG6jWnKx4HYvo+s6Bgrnq+5+KLJ0q77R8MbsgaMWr4FN/wlUJa2qNFr0qNLRMSl7yaMCo/mv1Dhviq3+3rq30vUFm5csDatb6Hrrn7d0WuxDvjTe83C5JvmeDR01fWBmLtDzTcOBaS5SOPXp/hWZh+PzMPF0KuYEkN1ec+ucLx0m9iU+6vCq2h0ry8W5j4DAb/Izt/+Ysh0JCbmwOBKwC8m5Vf+LBK7gRAARuDABsz+yAoAIl7VXKnri62tgd2R/wWWfmF09QVTVf7OVT9CGgIrwM7Mh7hNR7dudZ6oq2ugIaD9a+yM57WfH3REzJ2us0IaOg50DBp3rJbBXC6ilhYc9+skH/AxHkvnK1B3CwZH61ZPKvdeP+fakNqCa8E+Kms/OUh+UqbIyXM8y+YIt5YfYYy9TPz99kFy0OgoTRvxrkM8TwRGp4uHzVy3YnDX9QsUzxYsiY+xgraLaCi3BY9xK3bY1MD7u2x0l9DQLkhcdO/ksb+ssSRMD/K9O66p/yWUzxj015qMh36PXW3HguGLCt7L+ufYz9QQPr4FqfHtrooyptxsSBxJTNMQfyKuvMjpqlE0Eni6czCwle2Tpxod8VEPQmiExVwUP4YguQqeAL3Zrz6amvG2U6tkx/LMP30tnrZefHF8YbNeI4I8nCuQDoS5KeaE/8vyBEOuggHGSKWho5ma/g87w7QMALAVACLe/uzIqCh50DDBbcumaRr2nUMqmbi5bB4L4huEITE1jwOvWVpKM6bMYlIXNfe9UQwJ2+KtnzJ4NamflhYB8FXEMQlEtJHRPfemX7epIsaNp6eGWiwJZoek1jCSzbjo9h+24d7yx8b6K89BURJgil/afzw0iJX2lJ1PZFiNf3nXNe7fb4MHjV2J/o4bZZZeXvKgzeDhOJIgdBwg/O2vbvabs6cm6uVEisLyYkH6I3p42cKChapnBYleTn/C6IzFaslgHIC9rF3NVsiurrmfgQaOsFv0dU+OqofOaTC65dtZDzCazw6Wj+9/TwCGnpgBH6Wi3DBAjHJM3yREFAgcX9h5oqmRu3GFh6HngANram2VfsWy69bqLYnz1uSAElTSVoDfl/xyWmZZoMzzvJVt8ih5Ass+NOvB40cSS2m/gPkB/oTI6DYrKt1V6Zbc8T4SFg6S3eq5XF6hBHwQ9uaUbL1dFta8gSVGIqYP4ga95+nn6u68u1SkTqcFJ2U1OCATxtu24ZRxqY6j24LllrpZoUv5dNjS5r+m242xcoLpy4QK185S3Fy7JcvN1fbI+XVloC6WlF5qL/2V1Y+qa5AyqZP7ycN7XH1DWC6NbuwsKZk+vTJ0MVCBuka4RnL4g2t2+toOrc3Nw+iF+twr0AOR4aO3umJ5+GwTiMyhNeBHQ7j0RNzvTvbjICG7tRmc1vhMvG6XQ4FHPzDJwmmMZKZVchlnV975eM/56n03u2WI5VhASCuzMtZTCpbY6uifBN+02fKE9Jhf4AoFAGh0jfjJM/u1DHusvLjvHv+yxI7JfBKYNEiTwvdbUlOzjlCo9HMlCCZi9UPeCLtKiLEqIRPAaHjo5j+JfGWr7GPv87llGZdPPtrAXM+Sb2fSgxFwvdtwujPBpoB28AN/tHDSjjNps77E20bQJBWg+ZiEEwhpTTq4lBRM8ibFnRvdQ0deJoK/STwm5n5yx876Lc1X4EEiI5XRF8EvJ+ZX/hA6ayLslkaD4HodFIEF8yfq39a2uvMVD7YeLTVSyTksjPaPPI6R7o+jlyC8MiMqb4joovuGM2ebyMCGnpAx+Ew+X8ui7At1bbFTEIgR1Ft35d+tnu3MyFaMr4nyasgaDQRJqlvl0Hr+jUP/WL3ofRQnJubKAjPMMEAy9UgcRkzkomwBUxRIG4icDozSZB8BUxD1PWEI7lIOtKK7MH6lAHBusRKPa6myB5fdVqQtcR1waPxrW9YwwjX5nePl1tOsywj4bPqk6u+MIZ+dcX4jIv0V14O+VuIoHW9ZYiRIRrxZorv1hEf6gokyLxRE1igUl2bAYHhue8AACAASURBVPO3hk2/VV1VgEORS8VgFELs+96tIuHWB/qfLc1goO7NBy9XydfadV4Mh7kZDjL8XNZHd2xfkfEIL2tHd4xpT7bRHaBBJXnKA/CHnhS0M21HfBoO1FI4bAZHKkNbqm31hSV5eWdZzLPvzj63/x5b/A6Xg3ILF+QpGnVMnpuvLA/Dmfm+1Ysv+e+hDoddOTnjdY1ua4moKM3LeVyCBhM4GUR7VKQCAacQCcGSN0LAra4KEkd9nCIlxTduPqFBSvFJ5sjl93r1tE2N7Ep+sO63nOIJlHv+esfom/73qE2w+eIeodxt66wxlY9cfdxFztvnPag4Loj4PjCdomjE24v4UFcgBtOTAaKnvXYeYwkz0R4UCUKSyjn5mQZ+VTGG7pw58y9VmnPiNkcKmUKwXxjBUj12xydRfW9+7YFZ29uumyMdj86sw47qhIMMEdAQfgdlOMyLcJCho/XT28+7Chq05sROyhysWCdLAcQDUAl1QhnrerNEQMPPFzS0UG2HQENu7tksxM0LMs4euMcWt53IumL1ol/UqmeT5iy7X/ldSOKFa+675NNDHQ5FeQdGDpTMnDaUWb+XCKcyg8H8JRGlgdgnGKuYaYdWX78q5vQNS2XQltiw9Ri3NI0NWbz89qajUr9rRHTqY3VXwekVVad+//rIo46u+1ZzehIe55xt/+WjKh656riLXfNvu4uB43WSC02pnROiEW8V8aG+rTWN+Nq5U97IrOXTNFMI3Weo6Am4Y5saNzliJ07/S+HH/7n8t2v7ButPrNMdniA0t0XCxgTabk8qfhl9z3j1b9ceEGERDptiOMgQAQ0R0NDeWRUuc7M3z9GO+u4KaFDkOyor5PkAlgMYCeDvAK5R1uCOOvopnkdAw88PNLSOilBU2zCJha7doKi2/5Bxvl5hjzHB+NaS8nUhxEh1PcGgIGBe2QIkDrYRFLWJHFARFQTMZOLJKgM0ET6V4A1GbcOz6W++2dSi3aaFaU+z1AcG65L7BusT9xoxVVuMpIoLA2x3feY/mr72D6/OcJWsusBaPy1o6dEf15xZ8Z2R+cGlE0ZeYVvy/CqVJtps8lypRUVNbaERB2G5NHlvy7cpGvG3h9ubRhnbC6UlURdM+TC7yDFQ6NYAdnmNahdtzyxy3dWouf5tsGXUC9srmabn8XqyHVdlj5ptEenrHZm/nP3Una+3nhXhsCmGgwwR0BABDRHQcHincmdBg/qF8xGAouZ/HwbwGIAbAIxqpsk+PAm68a0IaPj5gQYVOVGcl/OgAJ1BBJe6qpeMBsH83pX9Zryk6WKu8gVo/eUs+enV91+yn73xYIfUzosv7m/YdOVkebIFMuo1h+ETejBIom5p/FF/yaguK7g8uP18xdap2ieJbcqxMmns+2MZmGf5nMM1XWZBSJ3BQi2meo6yKhDfKEmTDssygpXp1ODO8GYG6r7Thw09L+QI2ZyDoS2NeOgbWrgxLPnhtkwaFJdUNqEuGLd7+Nbof1tSjmFNnGS6fCo3itTcznd8Qj+nUXN46jzmkHNfei4UNfLGFde/Z4c5bLs98e4r/3bvExHQ0P4mEw7gJSJDeIGXcBiPbjwSe6SpzoIGRVj1tboyBkLZ6lRehmMBKPPvVQC6PT/94XxtBDT8/ECDOlj9xI8QaDQIiqBKXRw0EmhtRkHBbRPnLe0rQOcKcBYkVbGOtavvnfVtRwdl8YwZJwpBtzHxaAt6+hZHsr1Js6FGd5qbnan1RbaE7dn+uuQrK9dtj+KAypGw70xnrrAz3Wgb9maK3Wl/Wlr6MJZCyKC9lnSTSPdzg4zyfiVH7v44eFS5py5px9U1nwdjpJkYuPDCu5yrVo1Jz8/fL19rGvHW3BgQhKIk9Hcmlw1vCsR4+++MeU/179E43kquO0mYetBRHjWvzJl4h58EFyaM+fUTj16/RnGE/Mb/+fvpZkNGLRw3T/vXX5Z2pIvDWWtH8k64bMzhIEdEhghoOJK11BvvdhY0KEuDYrLcAGACgH8D+Kr5X+UI+V1vCN+2zwho+PmBhpLc3MsgQo62tSSxvHX0hDLhZxQWHmB+b28etrcxF+fk/J0Encvg5FrdxfW6U5NM5BNaQ73uLPvKlZnapNnE6KY9WybUbnpItSsEprUkd4oZ8/YXgoz7Aa4wTe+tcQsaarz3pp8hJW5hZnf0neWXtJXlYAcEn3mmvicxcbzUxB8Y8BKJ1RLm91Wx2myRUXYhW8xuX/JX5De+pajG86LsTUkey+4df887CWt+ef3bLjZHVejRjd85076OMv1xJ3hLRjulWZ/mq7+gf2HhzghoiFgaDrU/hwNwUfKFgxzhIEM4nKWHkqGzoEG1oTbufAAqb76yOPyzGUj8AkCIxKe3SwQ0/PxAQ9nM3HkSOIUtfqgliZGKnlD5C8C8NqtgeehA78qmqK48ymbmfM1MfRjwfeXKaJJExiBftSPe8kmw3LUuul/2e3EDbTrjtYceuf5Xqv0WLgsV2ZA49sPPJGO25Xdtqd907E5BlCylWZJw1Me5JDjgMvdeRAsg1RWI3a6fy4xMs53kTkV5eRcLlvNA1IeARGauk2xd33f5SysVN0ZxX/lygtc0NKmFokNYOWy4/KIhGPvN8U8tP/bd/7luqIOCBQGhp4WADcOKMb3l8ZbvuQH5+X/pLHDpSIfd+TxcNuZwkCMiww8zK6KL7lxlPddWV0CDkkLFh2erdLYA+gBY3xxN0XMSdqHlCGj4+YGG/ZwSbD2cVfDiu+oLWyIMWOKj7MLCdjkvDvXrWqVvLgEXE5EdLNc/k3IiPo/O9i0seWNIstmUAObSz6Ozk9+NG2SzmF55/JHfKWff/VwWqt/4o95ZyWbUc9Lv6uMpHvaNNG2m4aqNc2YUDRGa77PoPxVNDV2B6OI2bva5kMNHTFE+DWxZb141IO+jkz1Fk8Y37rphYKAeDhlQazGG9gHwGmL8wrICKdBtL/gMFtKQ1ZYuoQd1afjJaTDKMvMLxypqbJVvwqNpM7zCPjpReneRKb88WJbIyMYcOaTCEUgqmSJzswuHXS9W7QpoGNcMEpS4vwdwTLMD5AO9KP8BXUdAw88PNBwqegISBVmFheqqrEuWhu9yc21xhK3MHK28F6v0aKPUiCGXDOiZgQZ4NcNXrzkcJmlINt3e+GDTl4I0nYnjWVIVKSubWbPG2b/qI93piRciuBcsvpeg44i1WF9Vn3Wpf3tvasnMXEUnn6FIsjSJVYHp098PrnzltaXJ44ZtiMrc2SdQP8wlzRSNZdMxjbsfO8ldPBmChhBI+W18DJJuQExlwNSIr2WWuyTTtUJo50tmd3ZBYchBsyulNzZmlQ7b0sX1AA0QhLrAlAuvdP77+ejWESld+YbuqtsbugjHAzsc9BABDd01q3u+nc6ChpboidAPPQBrANgAqF95KnqiuBtFVRaMuOYcEC003DqAfipEvdnK0W53EdDw8wMN6iqhZGbuIsKPOS+UQ2JqYaGaE10CDapycV7OWlJEUZLJEoKq9Sgt2vJqGjN7HGQZZJmOAGy6xSxZyFphl0FhQJD0vB4z9MZLq9Zv14W83ZFSZDPia5MIHC1Z2+Pf288WaEqoyMovnF46M3clJNsJskiSNlCOGnXWsj1GcYkjIaHKcO0ZX78rqkm3J2x3JO7eY4v77MEdK7+N4uD/ENFQAjcwSCVnGgXmBoAbCMLB0mqEpikq+i2ZFZVn0dq1XboaVAdE2nMnjxWGOF1lv0TI4hJ80zW/pjvX8P7xUKmvpbT9mQj2lj+GLC4bN/3lmYKC/1WkXB2NX089D4fDMiLDD6Mb0UVPzfTubbezoKElemIGAHV3qn7hqJwNKnHMyQA+6SaxlN+ECuVUbc8DcByAjQDebHbCPBPA3QCWtddfBDT8/ECD+qIQYVVOziQIjBFEilgyxCmRXVh4UM6L1ppobzMqzc19mYlPEeo6gGFYRAaDoklYFEypqdKl5dMbo1OkZbeVafFY5+zv6xeo0eItv/zGmba9Qdjf/EXN+tPBiCGBbcLw2qXfpYivjiHmTTcXLj/3z7k5b4WACdBggfBi+ri0LRTPOkk2rOAXU2s39s0INsT+M+W47RuiM3eBMf+vO1YsEIRzmFEimZcLDbnM1F8wB5lI7NMHmwT6LKugUOVO6VIpWfssJ3x4eyiV9Q+FLUi6J+oPe7s9CqokL+9eEI9hVmm4xQoNGGmOHvWB+P67VQJiTkZ+vlrfvVIih9Q+tYeDHsJFjnDRRa8siE522lnQ4GgOr1RZH/cA8AOoAnAzABU9oXLdH2lRwET9akxSd7oAzm12vlSMgIqsSKWpVnV2AFBx6g1tO4yAhp8naDjSidV2I3j3zDP1wcmJL5PQxhHgZ8AhWTYKgQGK9cqVua3QX5GVzNDH77bFO6S04StHn/VHNVZoMRwY9r0z1f1ezICNd5S9O0pAcVPhRZZYB8JVRDSYmUuzCgqPLcnNKQZRCrOsXBfV/8OK+KRZmzkWhjQ521v7YLpsmnC0p2zY23GDrY2O1KZz67Z+dYy3bIQCScRYCLPpbehRX4KgsVpzxLXEKvsqKYPIluzC5Ud1RTf1C2ITzf4XVDtK3nsV4DVCiI2WxBRS64u4NOqO8t90pb2O6io9D0lNWaEYtRok8kYVFoacOXc//TfW3vrPKpZ4MLuwMBRK2hslHA6IiAw/jHxEF72xCrreZ2dBg2r5FAAftunijwDUf+2S43RdnJCjZYXKowPgEbW/AMqEilcBKB4B9fe3APxPM3g5oIsIaIiAhvbmXNvNiAEqycv9WqgDXcqPSOBtMEaC+DdMRBx0XyhEzHVMOH63MyZWg9Sy9N0LuD4xTmjaL9e7+tR9ENW/6uqqdYlOaQrQvhTqzCq7AlTip29mFxROeTgnp4wExYL53T32uP6+2PgR71FaoFGziTjLu3SznrRyRsP3f/s4pm+sBc26vPqL+oSAtwbEXxhMv/FKOUPXxYNy3+r6gghB7LtSGEXM1RmFKwZSF9Zew8LU8WbmaR/ZSz+8M2p++cKQzDfA7klLU1FRcM0vn9aV9jqzvkvycgtBcOgB88r0l16qKJ4wIZHPOrOavvjiNYAWZBcWrutMOz1RJ3JI7dNqOOghXOQIF130xHzvrja7AhpUn+oAPxoI3U+qX/w9YVocAODlZj8JFc65pBmYKNOpklddTdym+l+0aJG6qpjfVhm5ubndpZ9IOz9TDdgeehDw+yAHDYEcMgRi927oX34KloAcNhzs9kLbWwbTVJZ7ghHtBAUtldwJn2UeheLoZExo2ApHahI4JQXk9YJjYiC++w7QdQRnzoL9gftDUzZ4ztnYuW0vKvyEaE89PkcC/Kl9UG+LQp3bj0Tpw9muJhyXyJDJqZAjRwKGAfHBB9A/eA+cngEzLw9QfWgabH99UiW5hu/WOaB9dBSdKkbFl4jetBTBpBFwjwpFkYICjYj/5G6ABGpPvTf0b3cW/b8fgbZtA0dFAX4/xN49gM8X0ot1/AmwzjgDsCn3qEiJaCA8NDBo0KCunovhIfhPJEVHylHgQPkYKMfE9op6/ksAdd0k71kA3gEwBcDq5javBqAS1CgLg7omUQmmTlLJftr2GbE0HKiRcEDN4SiDip6IFVhDkgcLom8l7bOUacI3XpJwkZAVbOk+SG2QCdJMEhJMAY0tMsngfyYds63SHl02r+xdNiCDBH5GStqhkj8pMio1R7PyC+cX5+ZuEoLiwfzN00nHb/Slpd/grCz3ndC4y/2P5ONfbzLs4wVLa1rt91+dV7/ZDPlrADstUz7bb8WKHTtzpl1k04ynGBwAB28hiFJAXAcS56oEUlldjJ7w3Z06yJN12jZ76UerAH6GJFdB0BQGjfZV9jE8ewfv3pfGmndqpnw848UXQ9TiR1Iqp06N8TvtC5hxgSBSbbMVn5Auams/AYWuON/Nyi9UaenRNsqiPd6PI5Gl7bvhODe78/s621Y46EHJGg5yhIMMnR233qrXEWho8WU42N2pukpQ/gY/OsAP44NUXyqz5KXKFKuspQDUHahKJHUjAAUoBgJQGQCVH8WPnOAioCECGtqbd+1tBMUzc5eA0UeD9IKFH2BLCnOY5QxmbomLkQ6PEZ3eFLAJKckkmwIVTMzUIGzBz6P7bn01fsQdT+1+cTCYc0ilt2ZhMExL2PyB6H7f/0d3eUrqt4/MNBuTrhWEKJM0Wh+dKYr1WPmdq8/2UnvcZkWicV3Fx2ljvXtU3pP9hcCWs/83bxjOpnT3jjFXScvmkkG9kYikhIgKkrBtsyVufKzP6UtBvGHVokuU30+nyt7VCznmy8cPcIQMVKelesoHBNgyfgD/DJ8U/hv7LnulrFMNH6JS2aRJ/awY178JCEiTHw/eeedLtnvuOZMEbgGTO6ug4JL2oixCTTJt66koi3A4ICIy/DBxIro40pX207zfEWj4aaTY10tmcx4I5dfQUq4H8GRzNIWyaKgytpkH40eyRUBDBDR0FjSU5OTMJ41+p9gsW95xk+H8ILa/bXNsfOC86h3O/r56o144mJmsJKspqIixNEhyC9sro5Y+n1Ocm3sjEWYRIYZJxmh6IA56wB+VXrRZi66t95Zlj/VXZ2eBQ+6SJEFo0OxcbItrfCL9tHtmVn7hPKtp53Fg2hwMBB53aZowdb5JOD0X22Jqah1pRUWWNyrKU95/FAccwueP8dRpzrhNzqSKFQljtvl0e4gTgxlvrl48S1kEOyyhkMvnx58rdIxmSQmmz1Hj3j5uIrPRaEl+FB7PdyLKkUMkFL9MyGLSYaMdVPghgye9k1VQ8Gclw8ArrzRKU1NeBIEyyyunlaam/qltlAUTZjPB6Kkoi8ghtW/gwkEP4SJHuOjiSNdcT77fEWhQ+RGU06GyACQ0Z4Fs7fSoLiNfaA697Ek5VdsKTKgQz4PG5UdAQwQ0dBo05M54ikkcTcyKIbORAfcriaPP3m1P0ByWf+Os6g0JDljZJUYsr0wY3XhB5dcPDjfrfkNEKZD8lU50iSnwaIg+C7TGlf39JNOdMNLyRYNN/du4EZ++3rDppCekpQmW1EQmrZZJSXlUXxvKSyC8/uukw5EM4pPRKttl1e+Pvc9sTP6V5nDvcWVsuwuKPZPlDNMbn/Uf95muFcb42gbD9aUEvSZI0dMrGm9ABq3r1zz0iw6vE9puikV5008XpN3aOiW3ItEiQj4DVlZB4QyVdfJIFvfu3NxjNYEFAFXqtrobmhb81W2bN6/Z0sCerRVVv2gvyqJ0Zq7i4ji+p6IswuGA+P/b+xL4qKrr/++5byYJBJBFBbIgiPvWxbpi3X9WVoVkklqrbV1/Vu1iVdC69eeGWrtrq9Yu2laYSUBQwb/VinVpXVutuwJKEioigiwhycy75/85L2/CME4yL2FecoP3fT6tmrnvvXPPOffe7zv3nvO1MmzxLKuLbRllvXdvPtCQToOU1Er5wk9/7WdKmE6R7D2pO3mTBQ0WNAQBDV7dBym8xNDljBglEm2xWMzZZfSX1yno6Bmrn51U6rbNJqgDhPXyveJhNL7l41eHuC0DSdJ9mf+tGJdohy4F87Pl+9Td0BwZtUAOUX7y6pe1BgbD1fdTBD8DNO0w8q3awb94PS6TYvGsWWuhsIMi/RfWzstMfBSDf185t26eyL76goP/7G4adhwT14/+3SPnN1RV7e4MbL1LOakvbtQDije4QzcPcltuL9208bqyBx5onjzrvisJdDAz3/jQTadIhlGXV/bE3Fg741DA+aFsA5TH4xdJ9sSqqqpdkxElzKIby+fGP0W8le8d2b97FOBEd4F4kLCE6kMPO8N59p/eFolmfqIyXndrY21svkRy0lkWgsSaamM/BTCeNa6VLAsp/90EnAjiA9L1OtpWr14wbskSOVnZ7csuUu0qM0EPpshhii667cy9eEM+0CCilPlf+HJMO9cxZ9nzLFTK5TZ13YIGCxoCgQZZfAjziaCb12+s3X3x4tY7Djwn+s7h+65ziJ1TVj4/bQS1fQeECRud4uKPIgPVjm2b3h6kW4eAsAMz/R3k3ipf6Jr5uUquu6H5cyPnw3Xw8auHjVZKVbDmf0Fhorf5Qa1PuUy1yet/2lRy+ay1DOyQcjmuFM9VpM5kRkoRL5S9hkjxph8oR++onM2/1K0lP0u27PCQiiYPUMWbB7YgqpKbh+gBOvkxwHdWxuuumTxzzlVEOCjF+qaHb/padkr0p9SRPSkumzZtZHRA8R2yYHtF2livYdCRRDSYmf5aGY//YpsGpX9zY+30PZijlxDxqA4ODuYno+vW3yblpJtqqm9hIjkftZI1niDiXUF0iEQ7Ihpn35FIrDmzpvomam/TcRGwKqrxvSCVQbP7YcICYWXYYhWri0KMtPCfkQ80yPaEpDXKIcVcl2RPXNrVlkH4XdjyBgsaLGgIAhqkTUNNzV2ygEmkAEzy1XvY73b60s0bIyXRQW7LC8d88vbK4bpt0lpnwADNlCprW/duCdwhRCqqXf0bdlL3KkQ9FknJnigd+5/Tkp/sfEDbup1Ga40NRUPWLUhtGnIOa0cBKsmaX9BjKg9zGhu9UL+jccEo4M4m4stkcUzLrSJtOxftsHpIyeh3n93cuNszbRtG3uAUbygZMOr9959yP98a+WCnnXdrW7uDYl717V2mX+woPlPuTYEvfHj2Ke91Nt6EfnvFiBFjUpdftnTXA7/kZG45rKip+ooDda6cH+i4n+kttXnzVRLNCDKG27c06H8Z+qDsLBC5f/nRR5dERoyojKRS0c2zZr1WcsMNpZnPXhqLjSkivpqIOs40MSOpoG8vj9c/2lBbPZFA3+6gSCetFKgKREMV09yyePxPQeTMbGMXqXZtmKAHU+QwRRfd9eXebJ8PNMj2hBRf2acToQqZPbHN/bag4bMNGjoLX+u7796cnXstYXmCMyvNQCmae71458pHh+4xnsGy0jtjWz6O7NvyAQ1xW9yd9MYW1l7J6ReK2JkuX7aNtbGLwBBCqREO6SFMbSOAaAlFWpJFQ9au08lIcXL9jkPBEW+csfw/e6UeVlYmEhXe3w48MNo0btw8JnxRohKkeemQvf/xH1Wsx7R9vPPY1rVluzslG5qLh37w5hMfnvj2gkH7HfiDD5+Sr22aWTnpTVep9awxZ9HNp3QaEWioqZlE4DNAKG7/yn/zHtZ8W2ZhpeWx2Kgo877sYAcH+r3Rc+f9K7PQUybFNxGtc11+Oc2keQ2gzqqNCXHdHpkeSIzk5ta275YUR44lUpKOKtEMpA46eIp6/undxsy9X7g1tuCUWKxolaO/oLVTobVe19bW9uquCxd6mSVptlNO6aediJJDFg5pFDHhSwR+ojxeJ0UxunWZsEBYGbaYzOqiW+7bZ43zgYbslMu/AqgHIIWWVvj1GbpFmBNmTy1o+OyCBlm4Ogtft1z9ozPH77PPp3x9y0KoKoh4rU6lWlcX73DNGwN3HrLOKYnsUPqBGpNcQ3u2rGkmR38QKd64Pjr8g/+UcvICumb1xhU1VScrqJmSPQHwIGguZ0UOlJtyIskWnYqSTtJAUkqRV5eMhR9LK+JXyuN1XzgaiNxbU91AIDlknLl8tgwZ++8ftLUNPrFtTdkU1sRwI0+udIarf5TucuAJ698eykT60sqJb2ql1oPpvs6yJ4SemyLKy4Bgpk/05w441Xnl5QdlQXdV6wVBUiqzKb7TghL4kfK5db/0QAnxecz8ZpTpdtKakhF1voAI1nolKSVbnLKHKVuZI3mvvU+iN978s7N58zmBIxk11ZcS0Tlg/hBEazwZvJoSqGDGbysTif/r7txiF6l2jZmgB1PkMEUX3fXl3myfDzSILPJ1ICRVwvcgBFLT/ZLS8psQVQlpTl6mwd7olAUNn13Q0BG+Zl4DQp1mjqTD16lY7ZSx1dU5fT0dNodSaxRhIYh209p9b8DIFS8WDVl3km4rGdH6yYgWZ/Cq2QNHfLwfMw1VpOd+9O+jFinCbxmISPYEs3s+EUkdkShAGwh4lYEjJFGivTgT3kJF5f7U1Ci8LVCtbae4JZHpxKoGzG2aeTGBlSJ1IhNFHcZTyVTqeyoSEU4LKU+9ckXRkOgQ3TayRKeUy7z+onHTL8+XPdFQW30hgU5gjUffXb36tso770yWXHn59wE6jjXur0wk7s43NhtjVXcANJ6I31RJnXCj0b1B7VkbKuleoCORUyULhFP6usr6+mfl742x2LFQwk3D5XKmUTHdUhaP/70hFhuuD/rSGufFFx4EUldUzJ0vxdryXo011VcSqfOlqBVY3y6nTVVEnU+gUnb1/Iq6uvPyPiSrQc76HRnbLAS4gHpp84YNt8u5l+4+P0h7ExYpE2SwoCGIt5jRJghoSEsq4EG+GKQa46/8FEihrhbK6kIUd9pmjVjQ8NkFDenwNTHdWR6PC1cJ0vUB3BMnTtnlW2ds5eteSL2m6rTMsDmYjwajufyT9btuOuqVbxPjyOaGPSvb1o0cReReNWz/p9/RDMkwePLDfx/xVMShy5j1h0T0H2j8HwgaGsvIodGavQJlk9vjC3gVjDPbZs9+tnjWrGUglDtK/0yzmsaMXQk0vzzenqXQWFNzG8BnEvPyJOPMCOE3DNpVEXQbqYEaxFF2W4j5XxWJuqOmzLrviq6yJxpraq4E8cHQuKEikfiHLBBFl156qEQf5BDnmHidnFnq9PqgdsahKXaEPyJKjH8x0YeytUFEX5HnEvGN0Orw7CyQxlismsnLthpHwLvlH66uatp52IWKnCNSw0bMUB+vWcFMl1UmEpKy7V2ZWyCavWjCE5WJxH/kt6bqGZdqxzmHGB+C0BFpYKDCAd9ZFq/zuDS6c2Uvlp1ts0gdjfJ4/NJtTT3NJZsJC7YJMljQ0B3P7du2+UCDHISUg1ZH+pUaRdpXfD6IF3zuCWG9NOKyoMGChsyaB02x2DRWODt54sQp47JAW/zggAAAIABJREFUw/s1VTUOqdM8jTE3AlQG8FfAcDe+8p9RlaetuxCgwzYu36c8tXHHMofdywfv/9RHIDqbgSc+fuXw54jV7UQkY+RdgI/3jkQyf8zgZUrrelKRW7VUj+LkVRV1918rk/OAy2cu00zlEfAtKaZaEMYAybsr4vdLOF++0G8H4QzNeimIz/PeAS4FqGW9M2BMm1Lu8FRzMwH/rognJk2ZOecKyZ7QxNctuvEU7ys/82qoqTpbCjUR0xNlzD9dNnt2quiyy75LxP/DGv+vMpGQD4Ccl1RphC76ORMOZ40kQT8NpUpla0NDLyVSe0VIX9emMTo7C4SYphEhAs0DoaiZNYYoRXvKHglHozsjmWwl8Nqkaps0ds7Cf3W2BaJd/u2YuroFjTU1l4P1YSD9DKAghy216z37QA1+fEy87sfdnYSyF8sut1nAt1fOrVvc3Xfka2/Cgm2CDBY05PMUc37PBxqyD0LKeQaZmOQApKRZDgbwBwCbTOiSBQ2fXdDQUFM1iUidB+Y1mvRtDlQZM6aDaETyG9+aMm7SpK18vbGm+g/yWzqkLmFzEJYRUELMLw6sfPNFNaB5IreWVrR8VLZh4Mi3f+gM3ixMryOY3ds2vHLEZq2ic+VUIxHmaZdPhqId/cODS11OLXDgzJSKh8y8QjP9lPff96eR116XMDdH1284JDl48M9BOEy2J1xK/QRJ0pFo5GIGipTmOUTu7zPfce+wz39uz9bV+4xpWx8p1smGSyqnXC7ZEwxKAqkzH5p96qcifitPOWVH103+wk+h/ERPmHCq88xTXo2EzO2EXON3ZW31WRp0EjRGMOFjsH4ORKUgHEtMUQKWpTY1nzlm4MD12Vkg7WCM/uG2tj4XLS66RsvWJrMLov/qkSPH0wcfrFFEkmX6dnk88eXG2tgdEsmUbR1iWqzl8DXxZAEo8g6ntHQaiKvT9kWKWEWcCwEerjRuK0skpLx8t65P1awQYNLJNgtrPF2ZSMzu1gsCNDZhwTZBBgsaAjiLIU3ygYY0H4Ts1ea67PZEDq3YQbhFKb2lCynY1Fgbm03A3pkmYeCN1utuuGS33Xfv8HUhrNpBod6reDg3MSMddm6MVSdANFVAsHLc1IDydwcrJ6ko2rbCKdn0ljyXGG8McD+Y9d9Xqye4in5DYAdE74B1JTPtpRRFmTlJpNYx8yABIdwOsAmOcqB1klyeX15XV7tu6tRxGwaW/JvYY43tuBj88WnxujF/qa4+zHsH6x2Fd2IzFQ1YXjS0aAdudTapog23lh31D29t1nzXQzefsrCzOeWD6dN3TkWdcwA6SO+99zT1xhv1DP27ynj9ovQ9ky/98zFEzgEgHsYaDckUHvl907xveRUZXXcBkaqBwkhoDCWiYQysJcaF5YlEx3v/G4vtk2TeXQGuQ7RsdCLxujy/qXrGTay8Bb6NiBrdsvJ9acX7Vysncj4DqfJ4otIvtsXJtuTp4+6/3+PASG+tCLgpVuq1NkW3gXk/Io+XRspnN2vwE7+L1118jV+1UopCrZo+fSc3EhlGLS0NXR20zPbNppqai3Nts0DhG8T0cHk8fluh5+3eGh9dyW2CDBY0FNqzwntePtAgbx4iNWe6EOHj8MTr3pNtpGFrfZkwGfSmDO2VHqsngbG/HGJjptfKE4nFy5YudbNTLhtqYnUkKYjs3jImPu/va08+eeimoqJfM+sxDrBKg4azSq4ZXL5sWXTEqnXElGTCawOTHyyma6AbY7HDoHC51vqjiFL/dpmHatcd4Cjn6yAqdl39eJFSz6fYrSaldiemErekeIDT0voaFN8hWQdirfe+8pXRkcGD74ai3Yk5pTW/VFFf/w0CUvIOJswDeAcFSkn/tJStJpRsiAxYPWv0CTfq4sjjD93w1VeDjBTp49orrlg77uKLo7RkSUfW06SZc76rCMdvBVwY7symx5bumly3B7u8XCnai4lHQtMoEAaAsZIU35buR1fvb6iqOpscdSuzTirQC+7ee5+g3nzzUWb+siLa+HY8MWqPmlhcDnymi215YMMvIy1bIMpVr7UR/wqg/QU0eECMpfw3v1rM9F1JgZXqmYioi6n97JV3EfB3am65LRd4yPZNLxsmq9hWepuFU/qHlfX1sjVb0Ks3x0dngpsggwUNBXWrUB8WBDSEKkAhH25Bw2cbNHRnUkwfnPTvWUmSCgg4DLx099zEj9Jfrp09U7YzvOwJOSDYCTV2OuTOzK87Gg+2zZjx98iC+d7WgGQd5KOe/rCqalKbQ155aQI9y9p9CUrVQgAN0FwZTwzv7vjJXiBOuDg+riiifyFgRBEtcl33DaVoilRe/MLGpuS5q/8ZBeMAZjhEWAlCkjWKoPCxsFYG6ceKGTOOdCLO/5MogCL+W9vhEyZGnnlmpaRMaubNYxJ1wxprqq8H0QFSbIuZFjDp8bKAd2xPDBw4BQo1HcWdmEkpVKeLO6nidfOTrUPvIOIdJIIEYFUGeOig387UV7YuvDofWcW2BJooULwnxaOC2MaEBdsEGSxoCOItZrSxoCEEO9hBuEWpJugilwwfnHZCabJ16AVELGmRcm0ijYVlq1fHM7/Cu3KPhlhsOimcsVUb5uZUSn9vl3nzVmXzW4gcxZdddlU666B8Tl2XXBFNVVXns6MkKyAF8tKbhazBYaJjwbyxIlG3U2YBps5kjcXiTvOu7olE6oBpB1fcMO8f701+uPSdh3HNNXryJfd9mRy6VDM9u+imWi8DYeKFi4pV6fq5sqlyx7J64Yy4C0RC1fkiGM+oSOQO7brn5etHR7Et6GnwqjdiIIHW68GDRtKGjR9KOW0GXquMJ77031isUhPfAiJv6yF9kcZdsgWysjY2SwMT2OVb00Wl0tkxxPwkMz0ChWuFajvZ1naebHE0xGJHZdJvZ+unM99Mb7OQ4qTD6tWyREJq0hTsyixC5k6cdINa/NDkinj9w2FkZwQR2oQxakFDEEuZ0caChhDsYAeh+aAhLeEHJ5xQmhw8uKxizZrlQcFCpss0VFUdgAgdBcZwAr/nbmpZuMtDD61t/2rdmt9C/KLk8llXyzkBV+OmXRKJLrkiGmJVFyjlXOG67nvk0J8VqxGpVKrZidDFBOWWxRMV7bUEurquUZNn7tnB2bDvmKFTXlux7kHNeH3RgDcvm7R57yMU8SWs+bmHbj7FS788+nu/HzqweMA9ws1x8T9/U737TjvOJ6Ji2rz6a2UPLPlI2qS3DjrrR1axreEEGq+ZXZIthXHj9uTly//ikK4AqbVl/rkSid4Q6akMGgumNVGlloyaO9fbevGyJ7IYQdO1IOSQIjE/D4e+x8xPVvrVIaV0dib9drZ9+2KcZhchS/NwENPrZfH4ZX0BHPpCD7k81gQ5TJAhhCWpoI+0oKGg6mx/mCmOZ4Icn2UZMvktJOSePO3rrxT9+U/e9oRDzoWj58zplCtC2rxXM+2YKJXcJ/9OnLpbgxsIkdNBtKvL/PGYeKKz8u4dXj1x5pyJDsHjbGDNdWeesPuCu//6zp+IaKiGvo1d9Y7jCBunBDHwW9b0kaN4Cgj7seaVD918yrnZ/UhvHbRQdMBPRx2xdHnx8BEErAP0y0k39btHfnz6pkyuCGj9FIPOJsJoEK10J046KLJ40WwG9pMqkZVzE+fmG4aNNTXf6Cx7AhpxF3g9k3571L2PbNoSaeDminhdbdBIQz5ZtuX37CJkbaee9kDRn+79k7fN0sMskG2Rx85XW2vPhPlqW+0Z9v0WNISgYVMczwQ5PssyePwWrvoRK96LmUrVkCEj9CfrX4NSd6bZI+VruHHHHa+AokMVMbGmN5KrV18zbskSP4MgtsCvwCoMs4oJ8rXeohkzxyQSku7c5TVp1pxLlFdnhW99cPYpS8Qe37njhWNJ8UUMWvLQ7NpbJ82cc5EiHJP5IGZ5j3vDgzef+lwuno5WREoeGzJ+p4Uj9mvIuu/dh2568wdNta/9gIEj09sJPk/H6QB2RWnpYGzaJLTgq6DpykwOjM4680FV1SEppX5G4H0lJZWIXda0UYMfKyF1jtyXSb9NRJLaWtkOhviJXHUceuqbXnRJqSMV0Y6auUE5bY+Uz1mwlR4664ecpZG6N1rjJSJu8bYnFj10GYEmgLCkIl53az6bFvr3nurBFDm2xR4mAMlC6zHs51nQEIKG+/sgLKRKTNBFX8nw39iUg10aIBTcg+QgIUqKS9HaulYxP1YWr4vFAOcnNbF/KKIxWy+8/Em0pfXIkQsXrpIT/Q7T9SAMB1NUDkAy6eURilw8eu5c4YAJBBpYuz956OZTHxddXHDXs8c5UN/XjKcX3fRVr/bAiZfed1yEaL/MlMtHfnJKx0KYzdPxhxFfPOiZIeN2APPCZNum+qKiIfto4osIHGWNS+98v36KgIZ0sa0t/aBKPbB0MDW3g4YInCvy9UPuJaizqL2AloCn9CXnNzcN3tz6+aEPPLA8k3473UC2K9L024VYINIZFlvZS+i7oa7P1w+5p6F6xqWkJP21vbKltz3xxhtix+Hspu6orJ8vxF+9evXV+DDBHoWQoVeNZcDLLGgIwQj9eRAWWh0m6KKvZGiqiT2V5rJQGve6X/zir5xXXvZYG9HSOsMtjh7nkDpfs7uRQPdprR2H1Feh1ECleV4KuGJrfgt+A8ReZgOYmiri8f/NZ68TL/nzpIjjnMegNW6Sb5sZ2+e5W+a/fo8iDNea44tuPuXefM/I/v3oo6+JlB66d72Uv3xvmap5LVHTJm0mz5xzlVSndF394zvfry9NF9tydepeR0V/CPDuDFrrHn3M/s6Sv/04SD/SWSqa+SACjWJwkoAVDAwh0I5Sult4OkYnEl7K6LbUacinh8yMGRAeYBdvddceaQ6Ndpvr21JHH/cT5/Ely5RU2tT8y7JE4vp8chT6974aH9u6YGfbQ2l6k4knyrZX0PGxrTIU2hb94XkWNIRgpf46CENQhRHnO/rCHl4UIVbdACKqWPfJbvTII5u8g5CzZj0GRfsJlwW0msZEXwJD+DKuEv031tR8nwgzpSplm+brhd9C0hArfG6FdyZOLB44ZNBcLfSOcxPT82ZPXHONmrpp9x8Pd1uOKoY7cPiw0r0a1rU9ty5S8uqmDc53l9xe0xOyOZo8c45EUJy2VNuZj/z4dKkQS5NmzvmpIoyHdq994OZTX+gotsUYRkS7MfM6Bj/dds3/nYGLL96zZNDAuVJzQmuSoklPpJLJDcXFkeOZUZ7mnnCZB4sOiPkQBg3Rrv5ta3PzDzwdMA4gZqkiubw8UbdVUa8gvtxdv3ivuvpw3x4bFdE/pTYHWDcSOTOYkAxij6aa6ku1x9aJj4mwyo80/IMJOzPzb4KWw+6KqjxI3zPbdFcP3X1+0PbdlSNtDzlEWh6Pz5T3vD958jBn0MB7/MJt+cdHlnDdlSFo37andhY0hGBNUxzPBDk+qzLwgQdGm8aPE9pr3tC0co+9nn56gwcaLpv1NxDtK1wWLqtaKPocc/Kmivj8n3qgIRa7iBRdqrX7PBPfosi5JJNYavnJJw+NFkW9zIZ01kFXLvxhLDaomfjnzw0et19j8Q5DBg8bvFfxhytfOmR9w5I95v7lkp6e1p88c+4tRLyXHGRk5icAtasiPkTOQmilzl58Y83qjmJb4KkEOpJdvMJE30x++9vNRb++fREIBwroYeAFMIaCOQpFq7fqj+s+A8c5nDUfRkSDhKcj2YYfig6YeT8pPc3gpWMS9ft2dyh31zdX1Mw4soNvhPCOvI8YEQYOYPArd8frJuer79FRH4Rdj0NDzjQ4Dy26Fg59obOzF9n9ykdVHrYeuvv8oO17Yo9tHR820hDUOlvaWdDQfZ3lvaO7zp/3gT1sYIIcn2UZGmKxN5UiWQz/k9T8az7mqPqivz+5ipldZ/2GCXrIkMtBmCahag19LVKknWjkagIGSag6pZJzFKJeZoMUkALrj0COnBUInnUQi52WWRSp9bTTFhT96Z5tPq1//Mx7xhQjejUR7Zx2TymfDVK3PzS79tFMl11Re/L4zH64e+97v3r99Xfb+4XXGbQYYEk3LHI1z4koNT/NPcGai4Tyi4S7gjBEynCD+CXA2UkYNGVHQng6yurqhFGzW1d3ffO/selHCReIvISh6zXz64roNIIaC+Z3hEMjnwDZHCnu17/5XPTee/4oPChBsyc64+mQdwcptmXqQtlde2T7VU/Gh6m6yOdHffm7qaBBJgShv5UorFxSyjotq9TxX59LabYi5NZa6e4gDMMRCyGDF3IcOPBqIuwjdQk0463WZcuuHv/ii58EkbkQMgR5T3abptiMM5mcG6VctXcQsrj9ICQYt1ckElesmjZtZNuA4icVSPy749LM718UTxyeANz2rAOuJlkwWUUZvLk7WQfZRZFEF8WXXXYsiOW5gU/r5wqHX7RfzTObWt0vgFWF1npdspVffeznX2s/s5F1ef0AjpG8Th4yeApt2LiK4RWL+lFFIvFCU01MeCp2Yq1fcJSKgnit62IAOeRC66Wk1H7MOFqyVdsfzRKikJLaH50WrytbIgWwunnl8gsvOhKLTVQK+8vjXNavpAsvrayu/nI734jwb2AtM4RnpEURydaCUJVPyidCNkdKuk6DcKTcPTcxK1+koj16E1sARglpdyGUGk5E69jlA9ihnYWqvLOiYQ2x2AAFCPPrbiInabyrgYVts2c3Z5dZz9ePMH7vyTjt8KsMgbyKoBo3BMnKye5HT2QIQxcmP9M00CAnoyVNSoh0DgMgvBZp0qwXfWbN5QAuzwAUHfq1oGH7Aw2ysCZLiv9ORDts1TvmdZGW1qMkwyDfAOuriUDCyFB0CxHGEdMAPWTICLV+/QtQfE+asyELECVdzc9X1NVdmy7a1BCLfZcIXyXCYFmkAHigIUjWgeglIxz+k4r4PC97onjWrOOg8P3eDoc3VlcfB+j9MWr0T2n1h/9yWzfGxty/eKlf8KiRiEYS8zqQSvrAoJSZN0QUT6cW94uposhtWkhFvT0NwQsKYFcPaksdMnThwhfy+UG+BSK78FK6fbrwUkPNjCOInNuJ9RAiWq+ZomDdSqCRAF7/baLuuHyLfjvc2cKR4m1PLFo8RThSgmwViYxnxaofI8JemullUvB0xcDeBGyOkD5r1Jz6T1GkyzZVK/HPMyND3n3MH8oZk/H7CB7v26un41T8Sjm0HzMN624KbD6f6FuNmPn2PneULLXICWipSiesmntJQRo57+WDhPN90NCpJi1o2P5AQ2Nt1R0E5ySG3gRN97lIORE4tekMg9GJhBQu6vLq6WSU77n5ft9W7okPYrFxKYVfeNRMoEXM3c+eyA6Hp7793eeKbr/tnu5QShc6HP7+r29nZ8njD27FMwE1l4CIFJQCcC8TTyBSh3gbAZs2n0QDBgipVzmBmTTeEDaydhItIofRWJZIeDUZunNl+0VmQSrSqGt/h89voXGbi9RmlbE9Qcyvs789wcxNFfHEgd15v7TtiW82xqpfIqXKwLwMmu/TwGHKUVJanJ3WthNGLVjwn2w5GtPbVEIdrzFffleqnTo+FaudMra6us/Xgp7oorv6ztfeBBnyydjXv/e5o+RQgHxNSenYQ33QsDuAtzPaTQHwUC7FWdCw/YGGhprYw4ro86lkavYu8+Z5+/uZGQZl8cTkfIOoLyaCjDCyLmfEKJFo87cGAnNPSDhcO3TptmRPFDAcnpO2uqtweGd2Wfbii1x0043xrXgmGCd4RyKBJ6Fos3cv41AwIsrRM6HVT1yglFPuU2PmzfPODjTGYi8x8AUibgP4HGb1QGUiEZh1N9sv0lGZXPwWspWjNJ6T7QkAxUR4wxORoQj4HAP/qYgnJuXNZslSSnd9s337pPoREElk4RUmf1uGIfPkelL8vVzbE+ltKmKSTJ0HRIym2uqTGHSWe+LEKbt864w+Xwu6q4t8474nv5sgQ0/k7s17+txRcnRWtiNezgANEyCHoIBf+9GHvwLtA2T27NkSlbgi+xkxKZtjr+1CA9E//h7U1ITUl4+E/vKRXp+cJ5+E8+QT4FFlSJ6xNV+UMZ3WGtE/3Qv5VG2t/SooKlgYiPztMVBjI1JHHgUeO7ZLcWn5MkSefBK6ogLusce1t928GdFE3Htu29dO9T4X815aQ739FuiDD7z79M4joffYI/C929qPnPI1N0O98Tpo3TpwcQkij/8NUA6Sxx0LtWkTeMBARP79L2DdWiSPOQ7RRYtAbhJuZQVS510Aeu1VROvrQS2bhTsTes89gWgUycmTgSFb72Tl1Y/fwHn8caiGFUhNmAAe7237Qy1dCufpp+COHQuurPTswQMGAOXl4M2bwaWlUK+/DlVUFNweQQXK1c73K7gu3L32AjU3e7pSK5u8f+/Mr9J9cw8+GHqv9uxUkdt54XnoMbvAPVqOi9hLNGDC+Q6TLdEfQIOcc/CKx/iHIf8G4EwAy7IVayMNW2vEBNS8rTI0xKquUsr5dq4MA9fV94+pq8tb4GhbZejpAN5W7glTTod3xj3hAbgAHBrZ+stlj+xMEyL3oIiKfssb9JqrXSAOwmgF6BSnFis4XyCSdEs5CaBXK0fd7RX1AV6umJv41IdELhtmy9EVv4VkNqRU8p1tzWYJoot8/pa2BwGvag1hx9wHCt4hzM7skdk3EOpIaOC5fXsiWV0zZVws1udrQV+N00x9myBDPvv39e997ig5FJAdabhS6ucBkPKqcr5BDkR6kQYLGrp2HxMGwLbKwIDTWBN7RhHtktlb5i2llvMNom2VId/zO/s9m7Oh46Q801/T3BP5nm3C6fBc3BMiN3fRj1x8ADoZGSacDfr443+pHn30rEzOBsk0ATnXtR9z3HK5rn4p4mAeNB/EwNnMRF4eVftpSMmp0tyavNspiozTpD4H4KPyeGL/ztg/vYOnpSXThElTT512jVqw8Jg01bYcFmwj/gVA+xKxl9GiGesV8xN3Jeq9zIYg9vjviSeO1UNKLwfUeK15jQvMGVtXNy8IcMnnD/J7T+zh9U3RLwCWzLSOK+yDkPl4Ibqyh+djMv6rq690FB0i/+2y/kdFov76/OyuQTT56TZ9NVf0TNq+uctU0CCnfyVelj4I+YR/OFK0NANoP8hjQcP2Dxo6Jo7aqqvA6hAHYEm5dJubfyQU1EGGTV9OBJmcDampU67OXKSCyO4tEgacDs/mnnBdfjm92Gb3Ixc/g2be2SFqZeCTjDTDrTgblk6desSAAcVnaaaxSvGaVIrfdyJqV1k4XJaNGJ7kIQYPLFD7+VAGokQfud76zjt4v2v+d1ld3YTshaXpqydVso7+OH2WooOWGvyIZLNIZsIZNdW3KtCRRBjoPZ2xgUBLMmmru7KHzzdSR7QVRwbcZOruMfPm/TBbVz31ze7YI/3OzJRL5a2/WB5mymU+no589uiMmwWa3ytLJD5l36Djqat2PbVHId7dX55hImjoTHfDZEfXjzrkbGO3J7ZWiwkDwMqwxSafBV108AEAkY6MD+hqRaqamVtBanbb2Wf/OnrXHXm5JzKzNpj1aYAq97Up84DMXSWyriupQgk8y8DOBIwkpZpz8Tg01lRfD6IDJKxPTIvbTj75iciC+R5VuRRFcqNqHwJ5NOK5sifKEomH803sab4RyWxQjL9IZgMUHZcu6DX64Ye3okPfXn0iCE9HPnukIur0NDcLp9grquU46hTJnAqLp8MEe+Tzsb7+vT+Bhry6sqDBgoZcTmLKRGCCHGHLkMHP0MGXsXz69KOKiiJzmLG2PJ7Yd9nSpVpfcEFJVxwaGdknXtZGUVHkAwYVQ/MqOPQ8a/00kZKD0BEv9ED0kBT1YZeXy8LC7D5XEa+flvaH9hoMsXrZy5fnjbv//nXZ2SxgmpBJ5+1FeWpqjglaCCvNN0IE1bax+ZBdFy16X57RFIs9Knwjbsq9fEx9/e8yfTRse+SdNHuY9pnvubl4ITJ5U+6em5iRzx6k6fLOuFmy7ZtPnqC/m2CPoLL2VTsLGkLQvCmOZ4IcVobPVqRB+Bmy+QDeqzppUiRS9DvN+uPfxev3O23pUlf94AfDuuLQ4FjMaSIIKZZuXr+xtmTQoA1EUtxKfwhSz0VIX+em6DGtUEpyVJJxjpyRYLcolubuqEzUT01rP/t5uy9e3Cq+WXT5rFsI2Fuel9LOcSA+LE3n7YGGWOzYoIWwcvGNyDMaamLPypkcV/OPxiQSkgXWcW2v4yOXH2Typjw9N1E1oSaWYCDibmr+hmw1ZttDa3WlgIYsbpbrSNFZws2Sad9CTeMm2KNQfQnrORY0hKBZUxzPBDmsDNv/ApE5hHJlfDDo60TOdAavJ/Albeeed3/RHb+ZnY9DIytr4xIQCx22HI/7yE26rzvRiJeDS5qTKeWenc3dkU0znfk8MD2YOvnkf0UW3v8gMZKpTc1nOqWl00BcDSmARPo2pIhVxLmwO4WwMrNAXMZvHeaTIIWX/CyQskTiqc8EaMjiG8nFC5G5PSFZIO7JJy/JtIcaWHJhZuZUFLSHC6pV5HjcLGHQiJswX4WwJBX0kRY0FFSd7Q8zxfFMkMPK0L9Bg/eFDpyoWU9xFB0kTJQEWpp09d/Txbayh1CuDAMwKog4BdAAveNO+9Lq1S9nc2ikD0ICNEa4J1KuXuE4zjg5CEmah2vQ4d6ERe0HGuQ8pMsuXNddVVxU7InBzEVEvF5r+iOAFV70QTu7KXIOYI39GfgilMdr09JxEFLjrvJEYmGQ7Akv+lAz/fuKnCO0phEaWB7F5l+PTjz4nPwmWSAu1C0OoVS24LXUr5SzWORlzFRn66qn46M/UGPn401ZGYuN0cS3fOpgqm+PzjKnMrlZCj1999QehZbD5OdZ0BCCdUxxPBPksDL0X9CQ5mIA0/8I18GWnrBLRBuI+cmyeF3OSmrpDAOXeSiB32MXo8lRJxHxYB6x876cWdD5AAAgAElEQVT4qB00pDk0VlRVneE4Sg4qbjUnMbsvKqL5nNRf4Ig6FyCfsCotDSeR0nMo4owCczkTRUBbKsiyxi5KYZ1kbfh3DABjhAI93zp16tkDHnxw/1Fz50oFWgTJnmisrq4nR0nBuY5LM3MENGt0PP7Hxurqa8mhSyXs7gEbD8lAs6vnV9bX1xQCNPQXauwgvClyYJJIT5UU2NTUk67JtEe76uA0VlVdBcfLnHKzuVkKPX2bMF8Vuk+Ffp4FDYXWqI00bKVREwahCTKYEoHqji46uBiYvwyQZCCuAtN6EMoAlBJRK1paZ5QvWPBMV8Mom0MjV/aEx3JJNDw768B7bkvrDLco8lul1J5g1qTxTw2tFKmDWZFSGm8oYKrH09EeiXiAXbylmE+Fo6YxuAWEG+RvIJ5CRHuBqan1xhvPzaz+l497IsK8KemohLxCk/4rkvw8HPV1RTQGmteUJxL7Nsaq14JoAAEfOaBEivlwEKR+BEfXbzhk5MMPv5Kpq+7YI31foblAeiJDvmmzw+YZ9sjUfUU8/qmibGHIkU/OQoC47r6jv7e3oCEEC5rg/P1xkQrBFN4jrT22aLY7uvC4GDQfCaIJALdJRkDRoEG7etkEGnuSoiFE7lVlc+rv7Mp22RwaIkNW9kTVytqaJmaNXFkH8g6tSaIQw3VKLxxTXz9d3tcQi91PClOV5o/AqBaeDmGkLI/HZ8rvjdOnH0tFkT+zxobyRGJPqfCQeYK/7fobTxq/224dc2A+7glyuQUR50qpE1CeSAg3Dt6cMGHw4PKyt2UPoiKeqGyqiW2UfZPWTc0HjV+0yCOOaozFloJQDs23VNTVSbG6jqs79pCbsrNKJAvEe0dNzZUgPrgnXCDdlSHIOE3bPNMembqvmJuYns3TEYYcQWTdFnt09/nbQ3sLGkKwognOb8piaYIuTJChP9qjsabmciI+TDNPUKDWDU0r9xhUVnaQZBOAeS8iNThXRkD2kMo+SS/22Cp74tXXa5r23XsFgVjesdfTT2+QZzTVxB4D0b7yDiXstwrDWKceqEzMP9lfjBdAYQprfMzkVnWWtcGa11Yk6vaVsk+ZJ/hbrrvhpPG7794xB0p/u8qeIOYWpZwrtHZfrUzUCyMvlk2atEvRoIHPiuxl8cSuTe2RBmx47/3yvZ97Ts5OoKGmeiWBhmvNvxpTV3fxtixS6SwQeUY668B7R23sZskCcTVu2iXrsGW+KS6M8ZEve6JsbmJGNhV4GHLk63v27ybI0F2Ze7u9BQ0haNwUxzNBDitDz78qQ3DNbkVd0nwFWuNIJWyKzO+CaBODKwm0o2xPCC9EdkbAp0BD1kn6XNkT+bgnNHAXFPYAC1VT2x+QVNopip4BsKNdfhNOalo2L0Q6a0Mztyri72Sf4G+7YfY5mdsT+bgn2qi1NUol90n/iFN3a3ADIXI6iHZ1mT8eE0/ssyIWW6dIik7pRtZ0JxFVg3CA3OMwvj46kajbFtDQDkJq7iLiUd3hnujKl8IYoz3hTQlDju6OIRNk6K7Mvd3egoYQNG6K45kgh5Wh/4KGDr4Cdr8IqI6DkIz2g5DM9FSujIBcQyozoyKzjDQ0bqhMJJ7rjHtCM7x3rJk6dd/mgSX/kuJMWz2fOTVgc+sXRzzwwGs5szaAsWCsA8EL4zNL1WnsxC6/qE+advanuCey+RkYgwEkmSHnNlYQcS2R8kBA+pKDkMy4bEwi8YfG6hnXQzk/yNYBg96sjMc/78mQwafg7rHHiXjrzau7w6fQE+4J/72qKRabqBT2115GCt4Ns4x0EJ6OfACqnQq8XWZp67J+pSJeLyRdsiNU8MuE+argnSrwAy1oKLBC5XGmOJ4JclgZ+i9o8L5qY7EBCpimoY9VRAcSC6cCv9tVymVnQyqdUZE89vifZRNWeeMmi3simdRPZqZ1vnfCCeMiQ4bMg4JEOpg1N6bWr58x9pFHlqffmYsXglPRPZRD+4F5F5fpCFJeJsWWlEufeyKzv6ywm2Z3DwVnLxA+TD9fsjxVSr9PEarIlXIp7ZZNmVJdPKDk+wCVk8K6VEo/Naa+/gL5LZtPQQ8qHak2blrVXT6F7nJPpDNhvEOgGVfYhFXd4U3Jnis6k1nOSWRygRRyCjdhvipkf8J4lgUNIWjVFMczQQ4rQ/8GDSEMjz4D1fm4DsrmzfPKPvvgYbgi/JalCqWfjZHv9H8QXa2oqb4yk0/BPe64y4uWPL48TD4Frz+11RM9Xg0pXKXbCf+UaqfGTsVqp4ytru7ztSB7ruhE5moQDRWq8iBcIEFsktnGhPmquzL3dvs+d5RCdthyT2ytTRMGgJXBgobsMd4XPhGEe6J8Tl1H6mg+7oRcp/+DzGUra2IPZvIpiC6KL7vsIiLMDItPQeRKZ4YQ053l8fgD7X+rPolBZ7knTpyyy7fO6PO1INsvcsncHS6QIPYwwTd7Imdf3tPnjlLIzlvQYEFDLn/qi0XKVDlM0EVfyBCEe2LUnPpn03bryen/IHNZGjSk+RQ80DBr1vVh8imIXB2ZIeA7KubWecyeTbHYNFY4O3nixCnjDAYNmVwgaZk18xNj4nU/DqLz7rTpC9/sjnwmtLWgIQQrmOJ4JshhZbCRBlO+5vJxTwhpUgdoCMCd0JOpoyFWdVUmnwKOPv4PasnflobJp+CDhm+keTVAqJMDpczt2xPJb3xryrhJk/p8LfjU9kRN1SQidV6aC8SBKkvLbLcneuJ9hbmnzx2lMN1of4qNNNhIg6lf+CKXBVDt1umpHtKHMuWQojwnffq/MpHYHGQeyc46yOaeyH5Gd0//B5HBy5yIVT9DoD2IEOHiokFoa1vLmt+5KFF3eAJwgzynu206MmHAO2Xey8AbrdfdcMluGfUqunr2+5MnD3NKS6ZJ2WcFbNIuD6aIauuJPfKBScmcaKyNzZb6E9ky3z03MeuaEDIoeuqb3bVHf25vQUMI1jPF8UyQw8pgIw35FocgQ1AWvVbinxPRzlstIMwfFjN9d+dEYmOQ52RmHbRNnXp1NtfBp4BDdfVxknnBTMM0c4MQYJXPWdAQ5F252sjZirNqqm8GSGi7h2HQoJ2wcePbxFhQlkjMCiuVUGTJBF3EnGSm18oTicXLli51M+tVdNa3pq+eVMk6+mOfYMoBYz8iKmLwagDvyX2SjdEde2S+K9dc4aVcVldPgsL+JBmXvsxh6cmE+aqnvtVb91nQEIKmTXE8E+SwMljQUAjQ0BiLnQYFIXxaSxp1snoohfaT9Exzy+LxP3V3KPeFb2ZnBKROP/3+oj/d86cwMwLy6SWoHjKzT1jDBWEawMMA+i+n3Dspoo6Q7Y7+ZI9C+GY+/W5vv1vQEIJFgw7CEF691SNNkMPKYEFDISbmlbWxWRqYwC7fWllXt0SemT5JL2yb5fG6m7s7nvrCN7MzAvzsiWM9Pg/mJRXxulu7249tbR9ED9nZJ8XF0f8VexDTJ0y8g3BegLGTZGP0J3sUwje3Vf/97X4LGkKwWJBBGMJrP/VIE+SwMljQUIiJuSteCNZ4ujKRmN3dMdUXvpkGDemMAJGhZNaskySLIayMgHx6CaIHAQ1n18TqhPJbOC+c0tLzhKeDNbeRoqII6etcV42UfvQnexTCN/Ppd3v73YKGECwaZBCG8FoLGjpRqrVH/wcuXfFCQCNekUjc290x1Rd+0ZCVEeB+/ZvPRe+9549eWD+kgkX59BJUD1ttTzAxmKeAvO2JBmL3V0zqBOlHf7KHBQ35vOPTv5sKGuSErzDEpeuLRwDsAkAOO63qrJs2e2JrzQSdDLrvNsHvsDL0/wU7uLWDteyJT3R6+r/AB++C9aDnrbIzAjJ4ON4IKyOgM2kbqqoOgFJHuv9z/C8jjz7yTWb1QGUi8XFn7VfGYmM08S0dByGB/QhUxMwrQO3zcvZByPQ7FNGO+Q6S9sQvem6J3HeaIEOh+1To55kGGooAVAJYBOAwAOLAAwE8AuBlAEdDKHKBObkUYUGDBQ25/MKUicAEOfqzDJmn/5XHXYTlQrgUNOXSlK/KzIwAd+KkG5xFi6dIFkNYGQG5xsSKmqqTFakz5bc0cAFzs1Zt3x8zZ+HKToFGLDacSE+VlEt2eb3jOA4TF+eyR+Y70s8T7o4I1PWj58593hR7ZMphwvgo9CJf6OeZBhqEo15Awa4AhFhFiq18zf/3qwCUCh8MgN0BrM9WhgUNFjRY0ND1FGHCpGiCDKIlE+ToCxkaYrGteDWSZ517R9Fdd8xmYD/5OKuYm7hiWxea7Hewi7fycXf0hS5MBC7bqvuw7zcNNEh/owBeBXCoDxpuBCC10qUuvMj7KICvA/ivBQ12gQgyQEyYjD7Li5SpE7MJftEXMmTzaogMke98Z7gzaOA9xEiWxxMzgoyrrtr0hLujL3Rhqm9uq/7DvN9E0FDib0WkQYPUSf8RAAlnibyyNXGZRBxmz54tUYlPoeJYLBamzuyzrQasBqwG+q0GaPkyRJ58ErqiAu6xx7X3Y/NmRBNxMBGSp34dUgRjW66u3iHPbvvaqR7NpolXkEJXJsrdWzL1B9BwNoDlfoQhG1BspSe7PbG121jk3q4PE/Rgihwm6MIEGT7L9liRxavRdu559xfd8ZuCbk9kvwOsPwI5U2QLhIGVlXMT55r4lW+Kb/YWAOjJe/oDaKgC8F0Ax/hnHR5G+97bp+rNW9BgQUOuQWDKRGCCHFaGLR6yveliS4lslBPROtfll9OFsLLHRSavRuZByFRKf2/svHmf2vrtyeLSXe6O7c0ePdFZf7jHVNAgFLWSKSEHIUXG3wH4pq/QzwF4JZdyLWiwoMGChq6nHTsxb5+goaGq6hAVUZcJIVamBxD4kfK5db/M5RWNPq9G23HH/0xSLt1NLQszmT4LsYCl3xGEu8P6ZiE0Hv4zTAQNnfVaiGqa/VoNOdtY0GBBgwUNFjQEnTa3p0WqsTZ2B4AyAl4lpsUa2AfEk0UXKuleUDZv3vud6cUEPXyWt4uC+qsp7foTaMirMwsaLGiwoMGChrwThd/AhMWyEDJ4dR9qYwvA4GRb8vRx99+/TrrYWFNzJYgPFl6I8jl1kn2W8yqEDEF13lU7E+QwQYZC6DLMZ1jQEIJ2TXE8E+SwMmxxMKuLdl2YoAdT5CiELjgWc5oI84mgm9dvrN198eJW6V9DbexmAvZ2NW7aJZF4yoKG/JN9IeyR/y39u4UFDSHYzxTHM0EOK4MFDdlDzASf2J5AgwcQamruIuJRYH4WTJKmfhgUJslvDjkXjp4z5z0LGvJP9qb4Zn5J+66FBQ0h6N4UxzNBDiuDBQ0WNHQ+yRRqfDTWzjiU4MzKPgjJTH+tjMd/Yfq2wPYG4kJYVox5pAUNIZiiUBPBtopmghxWBgsaLGgIHzTIG7akXKoKIl7bVcplpkQmjFELGrZ1tu+9+y1oCEHXdhDahTKXW5ngF1YG65sWxPUOiAthaTHikRY0hGAGEyZmi9zNWhysPaw9LJDserI1Yd40QYYQlqSCPtKChoKqs/1hpjieCXJYGcxaLK09rD1spMFGGrZl2bOgYVu018m9JkzMpoAXE3RhggzWHmYt1tYe1h6mRn5CWJIK+kgLGgqqThtpMPErxoIGsxYIaw9rD1MXbFN8M4RlqWCPtKChYKo0ayKwX1LWHnZi7npwm7BAWBnMGqcm2COEJamgj7SgoaDqtJEGG2kwe7/UhEnRBBksqDZrsbb2CGEhCumRFjSEoFg7KZo1IVl7WHvYqIvZYNaChhAWopAeaUFDCIq1i5RdpOwiZRepIFOLCXOFCTJY0BDEW8xoY0FDCHawg9CCBgsaLGgIMrWYMFeYIIMFDUG8xYw2FjSEYAc7CC1osKDBgoYgU4sJc4UJMljQEMRbzGhjQUMIdrCD0IIGCxosaAgytZgwV5gggwUNQbzFjDYWNIRgBzsILWiwoMGChiBTiwlzhQkyWNAQxFvMaGNBQwh2sIPQggYLGixoCDK1mDBXmCCDBQ1BvMWMNhY0hGAHOwgtaLCgwYKGIFOLCXOFCTJY0BDEW8xoY0FDCHawg9CCBgsaLGgIMrWYMFeYIIMFDUG8xYw2/QU0DAGQlpUBrM+lvng87ixfvjw1c+bMPu2XHYQWNFjQYEFDkCnehLnCBBksaAjiLWa06dPFNaAKSgC8BuBFAAIYlgO4HIDOvt+Chq01YsJkYGWwACp7nJrgE3aRMssvrT0CroYGNOsPoKHCBwnn+6ChU7VZ0GBBg6lf+HZStIuUqb5pQZx5vmkANuhUhP4AGnYH8HZGD6YAeMhuT+R3KxMmAyuDWROStYe1h438mL91ln9277sW/QE0TADwJQC/BrAXgL8CECCxfvbs2dcCuCJbfbFYrO80at9sNWA1YDVgNdBvNTB+/Pj+sC72mX77g3KKALT5GhJ5/wbgTADLsrVmtyfs9oSpIWC7PWHWF761h7WHyXNFnyGCAC/uD6DhSgAtAG4BIOcb5ECkF2mwoKFrC9tQdLt+TNCDKXKYoAsTZLD2sKDBgoYACCFHk/4AGgQoPAFgV1/+GQDm5+qujTTYSIPJE4EJi6WVwazF0trD2qNnS3ff3dUfQENaO8MAbPajDjk1ZkGDBQ0WNNjoU9Dp1C7YNhKX7Ssm+ERQ/+2rdv0JNOTVkQUNFjRY0GBBQ96Jwm9gwgJhZbCRhqD+ako7CxpCsIQJE4F0ywQ5rAx2UjT1a876po00mOqbISxLBXukBQ0FU6VZi4MFDdYepkZdTFis7fiw48PU8RHCklTQR1rQUFB1WuRuInK3i5RZC4S1h7WHqQu2Kb4ZwrJUsEda0FAwVZo1EdgvKWsPOzF3PbhNWCCsDGaNUxPsEcKSVNBHWtBQUHXaSIONNHTuUCZMSFYGu0iZOEbtR04IC1FIj7SgIQTFmjAx20Fo1uJg7WHtYSM/NvITwnLT64+0oCEElVvQYNYCYe1h7WEXbLMjYBZUh7AQhfRICxpCUKxdpOwiZRcpu0gFmVpMmCtMkMGChiDeYkYbCxpCsIMdhBY0WNBgQUOQqcWEucIEGSxoCOItZrSxoCEEO9hBaEGDBQ0WNASZWkyYK0yQwYKGIN5iRhsLGkKwgx2EFjRY0GBBQ5CpxYS5wgQZLGgI4i1mtLGgIQQ72EFoQYMFDRY0BJlaTJgrTJDBgoYg3mJGGwsaQrCDHYQWNFjQYEFDkKnFhLnCBBksaAjiLWa0saAhBDvYQWhBgwUNFjQEmVpMmCtMkMGChiDeYkYbCxpCsIMdhBY0WNBgQUOQqcWEucIEGSxoCOItZrSxoCEEO9hBaEGDBQ0WNASZWkyYK0yQwYKGIN5iRhsLGkKwgx2EFjRY0GBBQ5CpxYS5wgQZLGgI4i1mtLGgIQQ72EFoQYMFDRY0BJlaTJgrTJDBgoYg3mJGGwsaQrCDHYQWNFjQYEFDkKnFhLnCBBksaAjiLWa0saAhBDvYQWhBgwUNFjQEmVpMmCtMkMGChiDeYkab/gIaIgB2AbARwKrOVBePx53ly5enZs6c2af9soPQggYLGixoCDLFmzBXmCCDBQ1BvMWMNn26uAZUwUAAjwB4GcDRAK4FMCfXvRY0bK0VEyYDK4MFUNlj1QSfsIuUWX5p7RFwNTSgWX8ADV8DsBeAqwCUAlgGYHcA67P1Z0GDBQ2mfuHbSdEuUqb6pgVx5vmmAdigUxH6A2i4EcADAJ4BIPI+CuDrAP5rQUPXrmXCZGBlMGtCsvaw9rCRH/O3zixo2DYNPAjgRwCe90GDbE1cJhGH2bNny1bFFZmPj0ajnEwm+wMY2jat2LutBqwGrAasBgqqgR133DF11llnRQv60O3sYf1hcT0bwHI/wlDin204FMDaXJGGZcuWtc6aNUsOTvbJJVskfS2DdNwEOawMW1zQ6qJdFybowRQ5TNCFCTJYe/TJUtXjl/YH0FAF4LsAjgGwK4CHAewHYLMFDZ3b3YTJwMpgQYOJY9QuUmb5pbVHj9fvPrmxP4AGkfF3AL7pa+hzAF7JpS27SJk1GVh7WHtY0GCBfZCVzc4VQbRkRpv+ABrSmtoZQLNfqyGn9qzj2UXKLlJ2kQoytdq5wm4XmTpXBPHfvmzTn0BDXj0xM910001Xzpo16//yNg6pgQkySNdMkMPKsMXJrC7adWGCHkyRwwRdmCCDtUdIi1FIj92uQENIOrKPtRqwGrAasBqwGrAa8FMYrSKsBqwGrAasBqwGrAasBvJqYHuONOwEYAiA9wGk8mpi2xtIZofyK1Zq/3GDAZQBWAlgw7a/ItATJN10JICmjNaVvmyii9649gDQBuC9jJf1tj1y9bm37CHvEZ/LzPDJ1f9AnCrbYDB55+qM+0Wucj9dOZPDJUz/EBnWAEiPibQ4owGsy9BRmP6Ryx47ApD/feDLIXL1hT1kfhBbiC7SV1j2EJ3v4M8N6fmosz6HZY/OfLA7suUbEp29I23jzPkxbJvnk7Xf/b69goZJAH4P4C8ApgE4MGtQFtJQosNfARjvA4avADgEgDiulLy+GcClADrN+iikMH7hK6mYeQAAF8A1AKSuhUzcHwP4nv/3Ar/We5zo4o/+gwf5k/B0AKKT3rKHTAKSbSOcJa3+JFkNQCalsO3hABgK4A4AP/GrmIo6cvmjgKpAnCo9MJT0Xfzttxl+sL+fdTQbQA2AGwDcHaJ/FAGQxW8RgMN830t3ZZRf0VX+/s9O9JO5iPZABd4tndnjiwCWALjV7/9BAF7vZXvIOx8DcDuAmQCOBfB4iPYQm//SHxuzAHwJwBud9Dms+bMzH+yObPl8obN3pO+TwoDp+bE4RJvnk7Pf/r49ggYpAPWaP1F9COA7AKTCl0wQYVx7A7gfgPxTvqak7PWLAKS+xG8APAHgCwD+4P8z+4urkDId5U+GUnb7ZL+uxUMA9vFlkxLcMmFIdc0wrhgAGbTCEyK+JWDhWQAv9KI9hJdE7CG1POR6EsDpAK7vBXuM9cGCACVZFKTfnfmjlEEPxKnSA0Nd5C9EonvxA/E5qW8ivin+KF+RslgLoJ4Xkn8c75PLSQRO+pkuxibROFkshXxOdPRqiOO1M3sI+d0RfhRG2siXp4D+3rSHVLoVn/wHgMP9lHL5wAhjvApnjzAEj/DBm9hGFmoBTtl9lnEjviGArtDzZy4fPBjARwFly8k5lDU+cr0jXdcne378aog278Gw7R+3bI+goQLA/8v4wpoA4AQAV4dkEvmikq9LGWCyHSKL1LkAfgFgsj8xDfMHqEQ8wtoqkS9pmQRk4ZbIhxTDkn5/3l8spPsS8RBAI5N2GJd80ctXvkRZ5JKvp3d62R6yKP3d/6oW/xYQI5Ok/K237HGfDx4EnHXmj+I3gThVemgoWQwXZABVAQry9Z70gYSUZpevLolICJgIwz8ErAsoyKzgKoBS9DIRwL1+xCHs8ZppDwFxMgZaAEjEQcD8BX45+t60hyxgcd9PBOSdAkC+fMMar5KyLnOUjImf+9u2sj2T3edLfLukI5WFnD9z+aB8UIkcQWTLyTmUNT46e4cAw+z58bqQx2APh67Zt22PoEG++CU8LF8y8oUl/32eH3EI0xqySP8NwOV+GFBCfzLw5AtLkL4sWjJ5yqRd6EtC8jIgvuGDkoX+YiFf2PJ1kY6ySIEsYQeVr8swLgEsUr3zJAAyScmX7okAJCTeW/YQgCZf+AKcZAtAFqkv+0Cpt+wxF8CP/cWxM3+UL/CcnCoFMox8QYocMilnnrERXxD7yJe2LAhh+kd22XdZKE8FcA6A9EIuX8Bhj9dMe6QjP7JN91d/+1DOFMiXdW/a4wwA/wvgJv8jQ+YOOV8Rpj3G+VG4Bt8Of87RZ9nSujLE8SofFJk+KB8VcgWRzeMcCjA+st8hNAS55keZJ8O0eQBR+1+T7RE0yAIte4MS8pOvekHwctgorO0Jsbo4s0xCsjAKWBC9ykQlC6iEoXcDUB/i9oQsTLInK5UyZWGUS75iJPwp/Rf55Mr84grDWwWUyFkGWbDT75M9W9F9b9lDFkRZDCWqIleaJVXs01v2yFykOvNHAW+BOFV6aCgJ5dZl+JxEPGSx+EEGoJIojFDPh+UfmaBBohzyVSvRHvmqFFApl9jqZyH7R7Y93gSwp18sLh2Ruc1fkGQLr0uOmwLYQ6JMEu2QCJjMD/J1LIua2EJC5mHYI/1RM8XfApFu5OL1kejg/JDskcsHRY6gsuXkHMqyR653dDY/SsRVQEhYNu+hq5h92/YIGtLhxzP9L10JxclXvkygYVyCkGUPMP0VOwDAJgAyCb3tL5iyryyHi+QLK4xLJiH5wpYoxr7+ATj5cpKT0iKb/E1O8gu9uGwhpNF9oWX5HwDyBSVhxHTmimRSyODsLXvI16wAFQk9S6RhsX+47Fu9aI/sL1tZILL7z0E5VXpopOxIg3zNixyyfSRhcBn76bMNYflH9uIrPipbFnJAV0CtgAX52s+ln0KO10x7SFROxoFEH+W9AiTlb5LpE4jjpgD2kEfInCRRMIkwpM88zfBlK7Q90tEVASXSZzkoK2NDAFx2n2UL9emQxmsuH5QPOzmDFkS2nJxDWfbI9Q7pa675UcBKmDbvoauYfdv2CBpE47JgyOCQS06Iy2Id1gFE+VqQiS/zksM9MgnJ14McQhQ0G2YGR+a7JapxF4Dj/D7LIi46kEu2L+4J0SXFn2TBlrCrXLI9IvvWvWkPWQDklHhaBlmcpN8Ssuwte0iIVyav9IHTXP0X0BCIU6WH9hI/kOdL9EvOeUjf5as+fcnZG5k0RTdh+YcsVrJFJTJks9KKfn4N4N+94B9d2UPGpkTBJPrRW/aQuUgOgT6XYY909kQY41XSbF/KiO7Ia+Uch4zVXH0OY7ymt1CzfVC2q2Q7MR15yidbV8Ohs3eInwtQlStzfgx7DPZw6Jp92/YKGkTrgqYlVC6TQV9dkvI13J8wwzoAGaRvgrLl+gnd7/oAAAWUSURBVBSdeJCbe9BGogwySCXikr562x4ig/j3Jxky9KU9Out/Xk6VHui/u7f0tn/kkq+3/UOicxIVzPQPkas37ZGWQQ5lSnpw+upte+Tqc2/bozOf7Q179MY7ujsmjW2/PYMGY5VuBbMasBqwGrAasBrojxqwoKE/Ws3KbDVgNWA1YDVgNdAHGrCgoQ+Ubl9pNWA1YDVgNWA10B81YEFDf7SaldlqwGrAasBqwGqgDzRgQUMfKN2+0mrAasBqwGrAaqA/asCChv5oNSuz1YDVgNWA1YDVQB9owIKGPlC6faXVgNWA1YDVgNVAf9SABQ390WpW5v6uAakQKqV6peCXFN2RSxgOpeR3urJof++jld9qwGpgO9SABQ3boVFtl4zXgJTyTmTQZ4vAUnZc/p5JI218R6yAVgNWA58tDVjQ8Nmyt+2tGRrIBRqESr3WBw0bAAhXxp2+uFIW+xoAH/vEaMKQKVUEhdtEymQLU58Qckn105l+qXDheBCa42t9IjNhX30IgBA0CQOnlO4V8iKpSiglhaWksVTRlHbyDLnO98thi7wSHZFy7GN8EjBhZ5QS0VKKWKIlvwFQ45fwlkqLwpQoxGWV/vue8vuUq6S0GVaxUlgNWA3k1YAFDXlVZBtYDRRcA2nQIOAgTR4m9f5l0ZdIgzAdymL8fwDe9UFAmitCwMW3Aci9whvxOQAXZUQphKDt8/5Wh7QTYiZhvLza51j4yAcbcr+ACmEDFeIqIUn6AwDhQBByLeErkPfLswUUCHeFyCjy/QXAxT5gWQGgymeUXeC3FwZP4XuQex/03ydKFIBzli97wZVqH2g1YDUQvgYsaAhfx/YNVgPZGkiDBvkSF5pmuWSBFa4UWZSFcEzq4aeJdr4PYJb/m0QVZPEWojSJNsz2IwNCvS6Mpm/5DIrC5Lij/9xdfJp0WegX+ov4kQAEiAhZk7AaCliQhV5k+qlPciXspOmoh1CvX+HLILIKAJgD4I8AhMn0Oh9syG9yj/RBni/0y9LHiQAetq5gNWA10L81YEFD/7aflb5/aiANGiQi8LLfhfT2xN4ABADIwitbAsKI+E0Ash0ggEJAg2wxpH8TcqOYf6gyTb0uv93gE4YJ/bSw/8k2hCz8q33QkH63RBheBSC05n/2owtyvkLmBjl3IfdN9wGFyCHREGFiFHllm+QB/3dhrZTtCdnaENmFWXMjgP/478s89Nk/rWalthqwGvAmBntZDVgN9K4G8h2EFEpxWexP82nVJdNCtjHkPMBPMkCDUPvKwi5bCbKlcRiA+/yve8nEkAiAfOELyBD6a9l2kEiEnIWQ/xZqajnzIG1kC0OiA0LlLot/mb8N8UMfgKQzPuTeQ32wIDTHafpz2QaRLZWvAFjly/+ED0TkHqGClnMU9rIasBroxxqwoKEfG8+K3m81kC/lstnPppBFXq5GALKdsNz/wh/pn1mQKIQs3HLIMH0tBvA1n/ZZtg4kgiDXLf7hRDnIKIt45iWAY65/aFG2EAQ4yCVbEBJVEIrzCgAN/vbFhf62iJyZkDMVIlexf0BStlLkkq0S6accrpT32UhDv3VXK7jVwBYNWNBgvcFqwFwNyNaDhPkla0KiCp1djn8eQn7/JKuRPEPARfrvElGQRVy2J94AIFkWAgoyLzlPkfLf213tDPafKTLby2rAamA704AFDduZQW13rAbyaEDORQhYkK0MiQbYy2rAasBqILAGLGgIrCrb0Gpgu9CAHGyU2glNfvbFdtEp2wmrAauB3tGABQ29o2f7FqsBqwGrAasBq4F+rwELGvq9CW0HrAasBqwGrAasBnpHAxY09I6e7VusBqwGrAasBqwG+r0GLGjo9ya0HbAasBqwGrAasBroHQ1Y0NA7erZvsRqwGrAasBqwGuj3Gvj/WAYzKkZAJpsAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<VegaLite 2 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/troubleshooting.html\n"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# load a simple dataset as a pandas DataFrame\n",
     "from vega_datasets import data\n",
@@ -433,9 +5130,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5.2.0\n"
+     ]
+    }
+   ],
    "source": [
     "import PIL\n",
     "print(PIL.__version__)"
@@ -472,9 +5177,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.8.0\n"
+     ]
+    }
+   ],
    "source": [
     "import tensorflow as tf\n",
     "print(tf.__version__)"
@@ -482,9 +5195,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from https://s3.amazonaws.com/img-datasets/mnist.npz\n",
+      "11493376/11490434 [==============================] - 3s 0us/step\n",
+      "60000 train samples\n",
+      "10000 test samples\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "dense_1 (Dense)              (None, 512)               401920    \n",
+      "_________________________________________________________________\n",
+      "dropout_1 (Dropout)          (None, 512)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_2 (Dense)              (None, 512)               262656    \n",
+      "_________________________________________________________________\n",
+      "dropout_2 (Dropout)          (None, 512)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_3 (Dense)              (None, 10)                5130      \n",
+      "=================================================================\n",
+      "Total params: 669,706\n",
+      "Trainable params: 669,706\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n",
+      "Train on 60000 samples, validate on 10000 samples\n",
+      "Epoch 1/2\n",
+      "60000/60000 [==============================] - 7s 121us/step - loss: 0.2455 - acc: 0.9247 - val_loss: 0.1108 - val_acc: 0.9656\n",
+      "Epoch 2/2\n",
+      "60000/60000 [==============================] - 7s 112us/step - loss: 0.1023 - acc: 0.9684 - val_loss: 0.0843 - val_acc: 0.9736\n",
+      "Test loss: 0.0842910062976\n",
+      "Test accuracy: 0.9736\n"
+     ]
+    }
+   ],
    "source": [
     "from tensorflow.python.keras.datasets import mnist\n",
     "from tensorflow.python.keras.models import Sequential\n",


### PR DESCRIPTION
- Update base jupyter/scipy-notebook image to 8/6/2018 version.
- Corrected Vega package comment.
- conda updates
  - bqplot 0.11.0
  - nbdime 1.0.2
  - earthengine-api 0.1.145
- NPM updates
  - @jupyter-widgets/jupyterlab-manager@0.36.1
  - jupyterlab-toc --> @jupyterlab/toc

