### PR TITLE
Add charts example using pygal chart library through geetools

### DIFF
--- a/examples/best-available-pixel/best-available-pixel-composite.ipynb
+++ b/examples/best-available-pixel/best-available-pixel-composite.ipynb
@@ -25,9 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import sys\n",
@@ -46,7 +44,6 @@
    "execution_count": 4,
    "metadata": {
     "codeCollapsed": false,
-    "collapsed": false,
     "hiddenCell": false
    },
    "outputs": [
@@ -84,9 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "a_season = season.Season.Growing_South()\n",
@@ -115,7 +110,6 @@
    "execution_count": null,
    "metadata": {
     "codeCollapsed": false,
-    "collapsed": false,
     "hiddenCell": false
    },
    "outputs": [],
@@ -228,9 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# List of satellites for 2000\n",
@@ -437,9 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bap = bap.Bap(year=2010, range=(0, 0),\n",
@@ -497,9 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "composite = bap.bestpixel(site=site, indices=(\"ndvi\",))"
@@ -534,9 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -584,7 +570,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/examples/charts/charts-geetools-pygal.ipynb
+++ b/examples/charts/charts-geetools-pygal.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# geetools chart module\n",
+    "\n",
+    "This `geetools` module relies on `pygal` library, so the returned charts are instances of `pygal.chart`. See options at \n",
+    "[pygal site][1]\n",
+    "\n",
+    "I made a JavaScript 'equivalent': https://code.earthengine.google.com/b2922b860b85c1120250794fb82dfda8\n",
+    "\n",
+    "* **Author**: Rodrigo E. Principe\n",
+    "* **email**: fitoprincipe82@gmail.com\n",
+    "* **GitHub**: github.com/fitoprincipe\n",
+    "* **Repository GeeTools**: github.com/gee-community/gee_tools\n",
+    "\n",
+    "  [1]: http://www.pygal.org/en/latest/documentation/index.html  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install\n",
+    "\n",
+    "You can install `geetools` using `pip`:\n",
+    "\n",
+    "    pip install geetools\n",
+    "\n",
+    "If you can't or don't want to use pip, you can install it directly in the notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment and run this cell if you want to install geetools directly\n",
+    "# on the notebook\n",
+    "\n",
+    "# import sys\n",
+    "# !{sys.executable} -m pip install --upgrade geebap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "from geetools import chart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make some test sites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_site = ee.Geometry.Point([-71, -42])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_feat = ee.Feature(test_site, {'name': 'test feature'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_featcol = ee.FeatureCollection([\n",
+    "    test_feat, \n",
+    "    test_feat.buffer(100).set('name', 'buffer 100'),\n",
+    "    test_feat.buffer(1000).set('name', 'buffer 1000')\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Time Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "years = ee.List([2015, 2016, 2017, 2018])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "col = ee.ImageCollection('COPERNICUS/S2').filterBounds(test_site)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_time_series(year):\n",
+    "    ''' make a time series from year's list '''\n",
+    "    eefilter = ee.Filter.calendarRange(year, field='year')\n",
+    "    filtered = col.filter(eefilter)\n",
+    "    return filtered.mean().set('system:time_start', ee.Date.fromYMD(year, 1, 1).millis())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_series = ee.ImageCollection(years.map(make_time_series))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chart: *series*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chart_ts = chart.Image.series(**{\n",
+    "    'imageCollection': time_series, \n",
+    "    'region': test_site,\n",
+    "    'scale': 10,\n",
+    "    'bands': ['B1', 'B2', 'B3'],\n",
+    "    # 'xProperty': 'B4', # You can use a band too!\n",
+    "    'labels': ['band B1', 'B2 band', 'this is B3']\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "68c7ea2b92c645f08593233c40086a14",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SFRNTCh2YWx1ZT11JzxlbWJlZCBzcmM9ZGF0YTppbWFnZS9zdmcreG1sO2NoYXJzZXQ9dXRmLTg7YmFzZTY0LFBEOTRiV3dnZG1WeWMybHZiajBuTVM0d0p5QmxibU52WkdsdVp6MG5kWFJtTFTigKY=\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "chart_ts.render_widget(width='50%')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chart: *seriesByRegion*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chart_ts_region = chart.Image.seriesByRegion(**{\n",
+    "    'imageCollection': time_series,\n",
+    "    'reducer': ee.Reducer.median(),\n",
+    "    'regions': test_featcol,\n",
+    "    'scale': 10,\n",
+    "    'band': 'B11',\n",
+    "    'seriesProperty': 'name'\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6fbf4bc1990640b49066dfd9fe9cde9a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SFRNTCh2YWx1ZT11JzxlbWJlZCBzcmM9ZGF0YTppbWFnZS9zdmcreG1sO2NoYXJzZXQ9dXRmLTg7YmFzZTY0LFBEOTRiV3dnZG1WeWMybHZiajBuTVM0d0p5QmxibU52WkdsdVp6MG5kWFJtTFTigKY=\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "chart_ts_region.render_widget(height=500)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geetools",
+   "language": "python",
+   "name": "geetools"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I know there are many options for charts. I choose `pygal` because I needed to include the chart into a widget. `plotly` is a great library that allows to include charts into widgets, but what I didn't like was the fact that users have to have an account. After making this module I found `bqplot`, may be my next effort will be towards that libraty, but by now `pygal` works fine and I think it is very flexible too!. You can even export the charts into `svg` or `png` images.