### PR TITLE
Update docker base images and package versions

### DIFF
--- a/docker/jupyter-scipy-notebook-ee/Dockerfile
+++ b/docker/jupyter-scipy-notebook-ee/Dockerfile
@@ -1,58 +1,59 @@
-FROM jupyter/scipy-notebook:177037d09156
-LABEL base-image="jupyter/scipy-notebook:177037d09156 8/6/2018"
-
+FROM jupyter/scipy-notebook:a6fc0cfbd01b
+LABEL base-image="jupyter/scipy-notebook:a6fc0cfbd01b 11/6/2018"
 LABEL maintainer="Tyler Erickson <tylere@google.com>"
 
 # Altair - Declarative visualization in Python
 #     docs: https://altair-viz.github.io
 #   source: https://github.com/altair-viz/altair
 #     pkgs: conda search -c conda-forge altair
-ARG ALTAIR_VERSION=2.1.0
+ARG ALTAIR_VERSION=2.2.2
 
 # bqplot - Grammar of Graphics-based interactive plotting framework for the Jupyter notebook
 #     docs: https://bqplot.readthedocs.io
 #   source: https://github.com/bloomberg/bqplot
 #     pkgs: conda search -c conda-forge bqplot
-ARG BQPLOT_VERSION=0.11.0
-ARG BQPLOT_NPM_VERSION=0.4.0
+#           npm search bqplot
+ARG BQPLOT_VERSION=0.11.2
+ARG BQPLOT_NPM_VERSION=0.4.3
 
 # Earth Engine Python API 
 #     home: https://earthengine.google.com
 #     docs: https://developers.google.com/earth-engine
 #   source: https://github.com/google/earthengine-api
 #     pkgs: conda search -c conda-forge earthengine-api
-ARG EARTHENGINE_API_VERSION=0.1.145
+ARG EARTHENGINE_API_VERSION=0.1.152
 
 # Google API Python Client 
 #     home: http://google.github.io/google-api-python-client/
 #     docs: https://developers.google.com/api-client-library/python/apis/
 #   source: https://github.com/google/google-api-python-client/
 #     pkgs: conda search -c conda-forge google-api-python-client
-ARG GOOGLE_API_PYTHON_VERSION=1.6.7
+ARG GOOGLE_API_PYTHON_VERSION=1.7.4
 
 # ipyleaflet - Leaflet-based interactiving mapping widget
 #     docs: https://ipyleaflet.readthedocs.io
 #   source: https://github.com/jupyter-widgets/ipyleaflet
 #     pkgs: conda search -c conda-forge ipyleaflet
-ARG IPYLEAFLET_VERSION=0.9.0
+ARG IPYLEAFLET_VERSION=0.9.1
 
 # ipyvolume - 3d plotting in the Jupyter notebook
 #     docs: https://ipyvolume.readthedocs.io/
 #   source: https://github.com/maartenbreddels/ipyvolume
 #     pkgs: conda search -c conda-forge ipyvolume
-ARG IPYVOLUME_VERSION=0.4.6
-ARG THREEJS_VERSION=1.1.0
+#           npm search jupyter-threejs
+ARG IPYVOLUME_VERSION=0.5.1
+ARG THREEJS_VERSION=2.0.3
 
 # jupyterlab-manager
 #   source: https://github.com/jupyter-widgets/ipywidgets/tree/master/packages/jupyterlab-manager
 #     pkgs: npm search @jupyter-widgets/jupyterlab-manager
-ARG WIDGETS_JUPYTERLAB_MANAGER_VERSION=0.36.2
+ARG WIDGETS_JUPYTERLAB_MANAGER_VERSION=0.38.1
 
 # nbdime - Notebook Diff & Merge tool
 #     docs: https://nbdime.readthedocs.io
 #   source: https://github.com/jupyter/nbdime
 #     pkgs: conda search -c conda-forge nbdime
-ARG NBDIME_VERSION=1.0.2
+ARG NBDIME_VERSION=1.0.3
 
 # Palettable - color maps
 #     docs: https://jiffyclub.github.io/palettable
@@ -72,7 +73,7 @@ ARG PYDRIVE_VERSION=1.3.1
 #     docs: https://www.tensorflow.org/api_docs
 #   source: https://github.com/tensorflow/tensorflow
 #     pkgs: conda search -c conda-forge tensorflow
-ARG TENSORFLOW_VERSION=1.8.0
+ARG TENSORFLOW_VERSION=1.11.0
 
 # Vega Datasets - Collection of datasets used in Vega and Vega-Lite examples
 #     docs: http://vega.github.io/vega-datasets
@@ -114,7 +115,6 @@ RUN conda install --quiet --yes \
     jupyter labextension install --no-build jupyter-leaflet@${IPYLEAFLET_VERSION} && \
     jupyter labextension install --no-build ipyvolume@${IPYVOLUME_VERSION} && \
     jupyter labextension install --no-build jupyter-threejs@${THREEJS_VERSION} && \
-    jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager@${WIDGETS_JUPYTERLAB_MANAGER_VERSION} && \
     jupyter labextension install --no-build bqplot@${BQPLOT_NPM_VERSION} && \
     jupyter labextension install --no-build @jupyterlab/toc && \
     pip install git+https://github.com/data-8/nbgitpuller \

--- a/docker/jupyter-scipy-notebook-ee/test_jupyter_scipy_notebook_ee.ipynb
+++ b/docker/jupyter-scipy-notebook-ee/test_jupyter_scipy_notebook_ee.ipynb
@@ -33,7 +33,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.1.145\n"
+      "0.1.152\n"
      ]
     }
    ],
@@ -70,7 +70,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5.6.0\n"
+      "5.7.0\n"
      ]
     }
    ],
@@ -100,7 +100,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.9.1\n"
+      "0.9.4\n"
      ]
     }
    ],
@@ -130,7 +130,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.33.7\n"
+      "0.34.12\n"
      ]
     }
    ],
@@ -161,7 +161,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7.2.1\n"
+      "7.4.2\n"
      ]
     }
    ],
@@ -178,7 +178,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f71e3aaca8424d5fb9f99611415a8f53",
+       "model_id": "c97043808bbd4335a70319590754c85b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -235,7 +235,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.9.0\n"
+      "0.9.1\n"
      ]
     }
    ],
@@ -252,7 +252,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0f5078813aef46ea844b0723c3d2caed",
+       "model_id": "604ac3f1664e4f6ea2de8c5edab7d159",
        "version_major": 2,
        "version_minor": 0
       },
@@ -290,7 +290,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.4.6\n"
+      "0.5.1\n"
      ]
     }
    ],
@@ -307,12 +307,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df60b1fc9ee64fccbd32d6f258e9e063",
+       "model_id": "558aca0011f4475b9b92c34a82828929",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(Figure(camera_center=[0.0, 0.0, 0.0], height=500, matrix_projection=[0.0, 0.0, 0.0, 0.0, 0.0, 0…"
+       "VBox(children=(Figure(camera=PerspectiveCamera(fov=46.0, position=(0.0, 0.0, 2.0), quaternion=(0.0, 0.0, 0.0, …"
       ]
      },
      "metadata": {},
@@ -347,7 +347,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.11.0\n"
+      "0.11.2\n"
      ]
     }
    ],
@@ -364,7 +364,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9a732ee9097b4d24bc8d4fd57f6faf5c",
+       "model_id": "6cc67a5aa9224e119176884c62f80c23",
        "version_major": 2,
        "version_minor": 0
       },
@@ -432,7 +432,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.1.0.dev\n"
+      "0.2.0\n"
      ]
     }
    ],
@@ -476,7 +476,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.0.2\n"
+      "1.0.3\n"
      ]
     }
    ],
@@ -530,10 +530,10 @@
     {
      "data": {
       "text/html": [
-       "<style type=\"text/css\">table.blockgrid {border: none;} .blockgrid tr {border: none;} .blockgrid td {padding: 0px;} #blocks2145b1ab-1494-4f3f-8217-20e9a2936fa9 td {border: 1px solid white;}</style><table id=\"blocks2145b1ab-1494-4f3f-8217-20e9a2936fa9\" class=\"blockgrid\"><tbody><tr><td title=\"Index: [0, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [1, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [2, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [3, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [4, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [5, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [6, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [7, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [8, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [9, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr></tbody></table>"
+       "<style type=\"text/css\">table.blockgrid {border: none;} .blockgrid tr {border: none;} .blockgrid td {padding: 0px;} #blocks6edf52a3-ea23-425a-b052-f8eb7351fc70 td {border: 1px solid white;}</style><table id=\"blocks6edf52a3-ea23-425a-b052-f8eb7351fc70\" class=\"blockgrid\"><tbody><tr><td title=\"Index: [0, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [0, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [1, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [1, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [2, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [2, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [3, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [3, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [4, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [4, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [5, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [5, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [6, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [6, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [7, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [7, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [8, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [8, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr><tr><td title=\"Index: [9, 0]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 1]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 2]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 3]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 4]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 5]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 6]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 7]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 8]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td><td title=\"Index: [9, 9]&#10;Color: (123, 234, 123)\" style=\"width: 20px; height: 20px;background-color: rgb(123, 234, 123);\"></td></tr></tbody></table>"
       ],
       "text/plain": [
-       "<ipythonblocks.ipythonblocks.BlockGrid at 0x7fe0a20ecef0>"
+       "<ipythonblocks.ipythonblocks.BlockGrid at 0x7f30fb066668>"
       ]
      },
      "execution_count": 18,
@@ -584,7 +584,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x7fe09e002e48>"
+       "<matplotlib.colorbar.Colorbar at 0x7f30f6809898>"
       ]
      },
      "execution_count": 20,
@@ -593,12 +593,14 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAAD8CAYAAADUv3dIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3XuMXdd1HvDvu3dmyHlzRI5EaUiatENJoZQ4ikZyUiGKLdkRbSl0mraIFDjIq2YLxIlUxAjspID6T4GmLdLUiBuDsBQbsCMjka3UVmXTamKXyMOKSEq2SZESVcoUn+LwNQ9yhvNa/ePO1BNqrz3nHN577jmX38+4sObuOeeu+9pzuNdee9PMICIi+ag0OwARkWuJOl0RkRyp0xURyZE6XRGRHKnTFRHJkTpdEZEcqdMVEcmROl0RkRyp0xURyVFbI066Zs0a27hxYyNOLbLEVKRtZW5RSHZ79uw5Y2aDV3OOaueNZnOXE/2uzZzfaWZbr+bxrlZDOt2NGzdi9+7djTi1yBKvRdpuzi0KyY7kkas9h81dxoq1DyT63amjX7qV5NLOaYeZ7bjaGNJoSKcrIpIbEmTikdIzZjbcyHCWo05XREqNICosT1eW6M8DyUdJ7iO5n+RjjQ5KRCQNspLoVgTL/nkgeTuAjwK4G8A0gG+Q/F9mdqjRwUlrGZ3e6bb1dyQbk2sdGo+uJ5LNDiGxJF3/jwL4jpldMrNZAP8HwD9vbFgiIkkRta4syQ1rSO5ectued7RJBkL2AfiPJFcDmATwIQBvm5qwEPx2ANiwYUM9YxQRiWqpRJqZHSD5hwCeBzAB4LsAZgO/twPADgAYHh7WdhQikgsyVafbdIkiNbMnzOwnzexeAOcAaDxXRAqiNnshya0IEkVB8nozO01yA4BfBPDTjQ1LRCSpVPN0my5p1//lhTHdGQC/ZWbnGxhTCRUlE+3FkTWG2PMKG51+w23LNkMh62ubPvZ83yvNUKinFJ3umlJUpJnZzzQ6EBGRLIhagURCxU+kiYgUW2sOL4iIFBOBSqU8XVl5IhURCVosjigHdbp1kTWhU+9kSvPPNzZ90G07fvFrqc831N3htvX7TXjl/KupH2vLgN9W/wSh1JOGF0REcsJ0Y7rlmL0gIlJkTD68oNkLIiJXS8MLIiJ5IVGpVJsdRWLqdEWk1GrFEbrSlf+vCKWq/uMcnfBnG6zv2ea2vTjybPD+8Rn/imNz35zbdmoy/KUZm/Z3eY3NlIBTobRl4Bb3iPgMhU2Rxyp6yXGrU3GEiEiu1OmKiOSGaYYXNGVMROSqEGDyMmBNGRMRuRq14ojybEypTrfBsu2A6ydmYufLYtcpv5b2jtV+2e63Tq4I3v/Qej/xdWjMT7KdvBRu626bcY/5+9OROmDHS2cPu213rPYfC/CTbJ548i1Gibm0yjR7IVGkJP8dyf0k95F8iuTKRgcmIpIUWUl0K4JloyA5BOB3AAyb2e0AqgAebnRgIiLJcHF3yuVvBZB0eKENQCfJGQBdAE40LiQRkRTKtbLj8qGa2XEA/xXAmwBOAhg1s29e+Xskt5PcTXL3yMhI/SMVEfFUKsluBZBkeGEAwIcBbAJwE4Bukh+58vfMbIeZDZvZ8ODgYP0jFRHxVBLeCiDJ8ML7AbxhZiMAQPIrAP4ZgC80MrBiCmeVs5ePhv3NiUNu29rOebfttdHw23nmsv9p++45fwbA4XF/tsE9N0wH7//P3+91j3lXb2x2QNhB5zkBQG+7/1p4hrrMbYvNhnj3dX7s3W3eOWOfiyyzDeq9q3OLzHggYMnHa0tRHPEmgJ8i2QVgEsD9AHbHDxERyVHyHFnxiyPM7AWSTwPYC2AWwEsAcv3LICISVSnGzIQkEs1eMLPHATze4FhERDIoznSwJFSRJiLlRgBVdbrXlFiyLJZk89aD3dyXLY6+jnBi6a+dkl0AuH6lv8btsUv+x+M/fa8zeH9HxU9UHRzxE3Nzs+H7e/v8L9NNnX7s3U6Sbe9ZP6m4uc9Plp285B/3LzZOBe9/bTSWfPNLrLcM/Lzb5suy63SeO1U3mK50RURyVJ4+V52uiJQc0XqJNBGRQitPn6tOV0RKjoRVC1JuloA6XREpP13pShLjM+FPSqwcdXLW/3TtORs+bmrOP+bIRLvbdnrMbcJKZ0XlI0f92Qs9vX4ck5Ph4y5f9s832ePPhpifC1/5VCJTiw6P+FdL79sYLnsGgM8f6grev67bn11x20CsJDo8s2Go2/9cxGbQHJ34avD+9T23RmIoGc1eEBHJkRJpIiI5IdIML5RiwRsRkWJLPrxQ/AVvREQKjVQZcPFlK3/0SnrHpv0dcE9NxqayhD8oRyZiu+b6b9mRiXDbtJ8DchNYAHD+nL9e7dykkySa9883dcxPHllX+o/ihcjVTcU5X39/5JjIF/cfz/il1F4Yq1deco8Zm/Y/F97OyFsGvN2jgdhnen3PtshxWRSwfFiJNBGRHJWnz1WnKyLlZgCsRLMXkuyRdgvJl5fcxkg+lkdwIiLLIlprC3YzexXATwAAySqA4wCeaXBcIiLJFaM/TSTt8ML9AP6vmR1pRDAiIukRaOG1Fx4G8FQjAslXLMMay8yGeeW8y/mOU+57esqfvfDmRf8tmxgPzxwYGfFnIbRFPgFzE5FSVedDXjl90T2kcnbSbbNIiat/jF/CjLPhuy+M+E94xVB4YXYAmJry32NvRsSuU/75Tl7yX9ufXRueDfPiyLPuMTf3R14LZ1fi+E7Vse9IwRY4T1cc0XSJ/zyQ7ACwDcBfOu3bSe4muXtkZKRe8YmILK/CZLcCSHNN/kEAe83srVCjme0ws2EzGx4cHKxPdCIiSZSo000zvPAIWmJoQURaCgErRn+aSKJOl2QXgA8A+DeNDUdEJINWS6SZ2SUAqxscS478ZFls9949Z5wtayOjNH/3lp8gWlENJ75ia9yOOskyABgdDSfM7C2/HHV2yntOQPWin+yh08YZfw1ZRB6Ll/w21zn/8sa6wq/h/ICzEDCA6Tf82OfXdrttHe3h9/8s/c/F+LT/uehxdjL+/nn/63pzv58sjSfMWgCLM3SQhCrSRKT8ynOhq05XRFpAQarNklCnKyLlpi3YRUTyZbrSLTq/omZs+qDb1uskTI5f9CvIbuzyExx/dSS8oWEk34QLF/xE2qyTB+KknxCrnvaTbIgktzjhLNI76z/f2NUIZ/01iT3W5g/ksSMcH89FquJW+Uk26/S/KqPV8HFm/mtR7fdjn45sJOr51H7/fPfccCh4/303PRg5YwHXzPUQQFtzOl2SvwDgQQDXA/i0mX1zuWNKNPwsIhKScIWxhFfDJJ8keZrkvivu30ryVZKvk/wEAJjZX5nZRwH8GoBfSnJ+dboiUn71rUj7HICtS+9YWGHx06hV5m4B8AjJLUt+5d8vtC8fatIoREQKiwlvCZjZLgDnrrj7bgCvm9lhM5sG8CUAH2bNHwL4upntTXL+a3RMV0RaBlPtHJF1C/YhAEeX/HwMwHsA/DaA9wPoJ/kjZvaZ5U6kTldEyi95p5t1C/bQA5iZfQrAp9KcSJ3uFfo6/F1fd50KzxzYfcYv6byUIRN9ccKfoXD5st+G4xPBu6MzFGKluef9TD+99WAjZcCxbP7svDPbIFJKW13hr1eLTqeUOrILL9r9WSjVN8fctvnp8HO+MOPHF8vpHOgKf54+cJP/fhyLzKC5c034a/7K+a/5QURsGYi1NmFmA5HHFuzHAKxf8vM6ACeynEhjuiJScqlmL6xZXPd74bY94YO8CGAzyU0La4s/DOCrWaLVla6IlF8dhxdIPgXgvah10McAPG5mT5D8GICdAKoAnjSz/VlCVacrIuVW5zJgM3vEuf85AM9d7fnV6YpI6bVcGTDJVQA+C+B2AAbgN8zsHxoZ2NXzyxhfOf+q23Zx1n/zbu4P3/+9c/76t0ciG0m+dd65/0RkjdvDF9w2eiW4sXVxY4m02MaUc+Hk0eRlZ0fIZczNhRNpHR19/jGx8ubL4fek2h5JvsWulub8BCZXht/jyrx/zFhHj9t2tjecapmMLFX809c7ZdkA/vKN8PnefZ3/fO8afMh/sIjR6Z3B+/s7Hsh0vkTSJdKyThmrm6RXuv8dwDfM7F8uDCKHFw0QEcldqmqzrFPG6mbZTpdkH4B7UastxkI1hv9nVUQkbyVa2jHJlLF3AhgB8GckXyL5WZL+3iUiInlKWgJckH45SafbBuAnAfypmd0B4CKAT1z5SyS3L859GxkZqXOYIiJhhloZcJIbss/TrZskY7rHABwzsxcWfn4agU53YTB6BwAMDw9HyqZEROos+eyF4o/pmtkpkkdJ3mJmrwK4H8ArjQ+tcWIzFMZn/LbD4+ln2F3X4Ze+7ht1HmvGP8ZW+OWelbcuBu93FxwHwHG/bX7GX1h8ejb8WDOzfqnqnFPqC/glwjNz/vnanMXDa23hcu7Oil+yzdEpt816Isc5r6H1+sdY5LLk4sVw42uj/vk6q/5re9tAeJbHzf3+rJs4f2ZQQ2cpePIpA66bpL3IbwP44sLMhcMAfr1xIYmIJEcAlRItaJCo0zWzlwE09ZJcRMRTotoIVaSJSMkl34kHKFFxhIhIQRFspURaMcR2Jk2vu83PYtw16K8Hun//D1I/1v4R/yWedUpp6azPCgCV0UhdilOqykhibnYyvAYvAMxGkmKXZ8aD909NO7XNiK+nW6mEX6fYMTHz8+Hy5raqXwbcZn5iLra2sJcV46ifiJxb609199ZMPnA229e10/m8j037r+2dazKtWoj1Pfmvp9uSY7oiIoVFILLWfeGo0xWR0lMiTUQkJ3VeTrfh1OmKSOlp9oKISI5SdLqavXD10mdLe9sPum1HJ/y2zrZwaen+C3555oULkZkDU+G2irfTLgBejJT0eguSRxYqn5v3H8uboQAAs3PhHYZjsw1iZcBeW+x8sZ2CvVkK05Hn5M2gAIBqpGzXIrsIe3jBn9lQ6Q/H7pUHA8DUqvT/vh7q9mfJrO+51W0bnX4jctZ0M43uvPO2O1MdEEKg0oJlwCIihUQokSYikp90FWlNp05XREpPna6ISI40Zazu0ifLjk5kK2M8NeknZw6Nhl+utZ1+QuLNtkipjPdJiZQBm7PzLADwjFOqGtnJNmbesiXgPPGS3nCMlYq/5mvsfPNOYi4WN2MbqXg7LQOgk/hkp59gi+3CfHEi/FqsGvB7lk29/vN693X1XU+3v2NTpDXdd3XPnv17MgWxRMoxXU0ZExG5KulmL5RjyhjJHwAYBzAHYLbZQYuILNWqY7rvM7MzDYtERCSjVu10RUQKp2zzdJMuiGYAvklyTzO2LBYRcbGWk05yK4KkV7r3mNkJktcDeJ7kQTPbtfQXFjrj7QCwYcOGOoeZn28cC5f6AsA6p2wyVgZcjbzC1bbwpyA6Q+GyP7MhiwojuwvTj8M7bh5+Vr7eYmXFXuzV2GwIRGZXzERe93lndkjk8iv2Hledt2RVpNT3wrR//fStk+HPZ3ebX4rc73+ko2XA/R35L2IOAJX0ldhNk+hK18xOLPz/aQDPALg78Ds7zGzYzIYHBwfrG6WIiGNxeCHJrQiW7XRJdpPsXfxvAD8HYF+jAxMRSYQAyUS3IkgyvHADgGcWAm4D8Odm9o2GRiUikkJB+tNElu10zewwgHfnEIuISCaqSMMU/HU16z3QXt+dgn/nNj+Z8h/2hpMws+a/4yv9DWaxYkX4uKnI7r1RXnJmIpJwiqwhG2vzVCt+BiZatuuUHMfOF42j6idEPdEy4NiauU6pt/VGYo+Uh7c5D7W2y0/mdUUW/I1UI7ti60rH1tptFi1iLiKSEzL6N6xw1OmKSKnVNqbMtqhTM6jTFZHSK0rhQxLqdEWk9Eo0utCMTjefBNv6nm1u2+j0Trdtzxm/omp4TfifMOMz/lveFRlsGjkdPl+sWmm+308QVSaddV0jy97FkkexarVqNZIhdMTW560yfcKsva079TGxxFyl3X9trSuy9qyF38fYmrmxzUIrlXAcp6f892plJJH24856ujHjM7FLxyzf1fD3vh4bU2p4QUQkZxpeEBHJCQk4y5gUkjpdESk9anhBRCQftTHdZkeRnDpdESk9zV7AStS/3NfjPY5fHtzf8YDbtrnP30X48Li3Rqv/T5vzlyOzAypOWWd7xo+QU6pqHZE1c2f9jH3HfG/qEGbn/DVaO9r983klwqT/WsTa2qudwfvb2sL3LwTht0VmocyvCs/kmI+VAUdmQ3R2pb9s+8BNU27bjZHyYc9Qd2w2SZbS+/D3tD67AZtmL4iI5ClFIq1VF7wREckH023FowVvRESuloYXRERy0rKzF0hWAewGcNzMHmpcSGmFB/Vjm+cBsbb0Rqb8RFVvu/8XuLsnnJy5fMo/Zn61nwiiVwbcG1lbdtZ/rPa5Hv84R1tbl/9Qs5fcNi+RVq36CZ1YCfOKjv7wMV2RUt9IwhGRUmp4x0XKuVes9hNp/f3hx4qtmRuztjP82sY+m9k1aWPKpjxqNmmudB8FcABAX4NiERHJpEzDC4n+QJBcB+BBAJ9tbDgiIuksLmKe5FYEScP4YwC/B8Ddb4XkdpK7Se4eGRmpS3AiIsshah1ZklsRJNmC/SEAp80sOonZzHaY2bCZDQ8ODtYtQBGR5VRoiW5FkGRM9x4A20h+CLVSsz6SXzCzjzQ2NBGRZFpq9oKZfRLAJwGA5HsBfLxYHW44W9rfkS2Levzi19y2NSvCoyvvW+uXYL425r/EU3PhzLy9y58BcP51fwaAt42s9UVKOiOlr5EqW7TDmdkw7+/4GyvbrVYii4R7x8QWUl/pvBaxmRyR2Qvz1/mPZc5jYa2/yLq3EzTgvyW/8A7/ve9u89/HU5Ph133LwGb3mDJZHF4oC83TFZHSa6kr3aXM7NsAvt2QSEREMiDji04Vja50RaT0NLwgIpITLe1Ycl7SAQDuXBMusz160U/AXL/SX8t0ej58volJP6k0dr2f0JmfSb9uavUHo26brfCfF3vDj8XRyHq6iCSxvAQcIwmnvlhJr/M+OmsOA4BF1r+dXxV5LCeOrsi6uLG23o70HchQt//e3zXoVe1nWRcXaFapb0zLjumKiBSROl0RkZwQQHuJhhfKNP4sIvI2i4uYJ7nV/7H5TpJPkHw66THqdEWk9OrZ6ZJ8kuRpkvuuuH8ryVdJvk7yEwBgZofN7DdTxZrml0VEioaoLXec5JbQ5wBs/SePUVtP/NMAPghgC4BHSG7JEm/LjumOTu902/o7Nrlt993kl0a+OBLO9t42EJ6FAABj0/7ftR8bmA3ef/C8P3uht8f/5Jx3FjhvWxnZyfZSOAYA4Jg/EwEd/nEei+xyzDlnTG7eH6uLLTpuA84sj2k/yz+33l8q2i31BdA9GJ71sP4m//lu6vU/M+9y2k5e8s/3rzb5n5mjE+Edrvs6/BkZsR2zi6ieQwdmtovkxivuvhvA62Z2GABIfgnAhwG8kvb8utIVkVKrbdeTeJWxNYtL0C7ctid8mCEAR5f8fAzAEMnVJD8D4A6Sn0xyopa90hWRawMJtDd+N+DQI5iZnQXwb9OcSJ2uiJReDvN0jwFYv+TndQBOZDmROl0RKb0cyoBfBLCZ5CYAxwE8DOCXs5yoZTvdWLIsXsbol0beNRg+7pXzr7rHeDuxAsCzR8OJjHtv9Nfn3QW/DNhbo3VkxI9hbmN411wAqJyccNu8VHDlhH+MRXbHZSTB5Z4vUrZrnek/2tbtJ6NW9vmJtJ7u8GuxqsN/3e9aM+22ees2e2XoAHD8YqSs2Hla8e9IVt73p3Glw4uzFxJaQ3L3kp93mNmOf3I+8ikA71343WMAHjezJ0h+DMBOAFUAT5rZ/izxtmynKyLXjhTDC8uO6ZrZI879zwF4Ll1kb7dsp0tyJYBdAFYs/P7TZvb41T6wiEg9LO4GXBZJrnQvA7jPzCZItgP4W5JfN7PvNDg2EZFl1YYXEo/pLju80GhJ9kgzAIsDde0Lt/KsLiEiLS/FhW7WKWN1kyhWklWSLwM4DeB5M3uhsWGJiCRTK45ozoI3WSRKpJnZHICfILkKwDMkbzezKxeD2A5gOwBs2LCh7oGml99Cy0Pdfhb9tVE/4+w5PeVnym+NlBzvmw2nqd8TqRB/6fXIJ/GdvW7T5cvhf+zMOqXIAMBxP2PvfiO88mDEdzn2Sp+rkcuMzk7/tejr9w+8risc48/c4M9COXfZf6wHhsLv8Z4z/uyK2MyG9T23Oi3ZZvHEj2vOAudF6VCTSDX8bGYXUNuYcmugbYeZDZvZ8ODgYJ3CExGJIw3VhLciWLbTJTm4cIULkp0A3g/gYKMDExFJgqjNXkhyQ/a1F+omyfDCjQA+v7C0WQXAX5jZs40NS0QkuXrO0220JLMXvgfgjhxiERFJLWVFWtOpIu1tsiYXwrzSYQBY2xkepRmf8dex/esT/hqo67rCa9zGEnPXrY6U0po/BjY+Hr6/o8P/SE10+aNZbc4yUXOzfgxd3elnxEc2F47u0Luuzy9THnR2fJ6MVDYPdfklwt6O1LFkWWxt3GzJreLt+OtiLmsv1I06XREpvRIVpKnTFZFyW5ynm1DxK9JERIqMANoriYcXip9IExEpujIVR6jTFZFSY4FKfJNo4U43axljTPi4/o5sMx688szYouixnYf/7q3wTITrnew6ANy7zp8p8Y9n/Ix4X4aFu88M+LMovOMmZiIzL1b4z+vSbDi1cqMzwwMAuqr+P1F/fsOk23Z4PPw1+te3+IuEx97j3vZwHH45LzA6/Ybb5mvEd6Q5lEgTEclRbCpg0ajTFZFS0+wFEZGclWk9XXW6IlJ6VEVaERQ/EXB0IlwGvGXAT5j0tvsLvJ28FE4s3djlJ5zGpv1rhF/dfMlt+/yhruD9HZFk1ECkHPn2VeEEoZekAoDxGT/2d3SH1+7tafcTfb+22U+Wxday9XbvjYmtwdzf8UDq88WTuZ7if0eSKtGQbit3uiJyLSCUSBMRyVWJ+lx1uiJScizX0o5Jdo5YT/JbJA+Q3E/y0TwCExFJYnF4IckNJdk5YhbA75rZXpK9APaQfN7MXmlwbC3CT1as70l/zPiMX8n00Ibwn/v+js3uMX9z4pDbFrO5P1zZdWTCT5bde4Nf/Xbucvjvf6zqbHhNZKNLxx2r/Yq+8Rn/cmmo24/DWzPZS5QCwPqebW7b0YmvOsf4CdZWSoplkeJCt+lTxpa90jWzk2a2d+G/xwEcADDU6MBERJJiwlsRpBrTJbkRta17XmhEMCIiWZRpwZvEhRwkewB8GcBjZjYWaN++OE4yMjJSzxhFRFxJr3KL0i8n6nRJtqPW4X7RzL4S+h0z22Fmw2Y2PDg4WM8YRUSiKrREtyJYdniBJAE8AeCAmf1R40MSEUnhhzMTSiHJmO49AH4FwPdJvrxw3++b2XONC+takU/G+cURf93UtZ3+X/8tA7e4bUPd4fVb+zs2uMfE1nwdm54K3n9ozJ8NEeOtSXtx1v92xnZujsXutcVnG/hiMxvk7YgWW0/XzP4WxRkOERF5m1a70hURKbQUfa7W0xURuVoppow1vThCna6IlFrKnSOaTp1uU3kJLj+hE0tueWIJovjmhL6x6XBJb7+/TGwm9930YKQ1v40Vs61XK3kpUZ+rTldEys60c4SISJ50pSsikhO2YHGEiEihZSuhaQ51uiJSerrSlYTqvYOrl83PNkMhvgC71+Y/VmyX2/6OesdedPnNvGh9RVpDbHnqdEWk1GpdrjpdEZHckOVZ8kadroi0AF3piojkhGDyxR214I3UU70TMFmSWFljSJ+Yi61x65cjZy2Jrvdrq2RZPaUYXmj6gjfLRkrySZKnSe7LIyARkfTKs0takj8PnwOwtcFxiIhkwhT/K4IkO0fsWth6XUSkkIrSoSahMV0RKT2yPIXAdZvcRnI7yd0kd4+MjNTrtCIiy0g6nluMq+G6XekuTLvYAQDDw8PlWdxSIoqQYfdjyLawuMpvW5GGF0REclWeirQkU8aeAvAPAG4heYzkbzY+LBGR5Fpt9sIjeQQiIpIFSbBEaztqeEFESo8lWsZcna5cY5Qsa0260hURyYmGF0REcqZOV0QkNymWdmw6dboi0gJ0pSsikguCqGi7HmkNKpmVslCnKyKSm2ZVm5HsBvA/AEwD+LaZfXG5Y8rz50FEJKi+q4x5u+WQ3EryVZKvk/zEwt2/COBpM/sogG1Jzq9OV0RKb7EUeLlbQp/DFbvlsLZg76cBfBDAFgCPkNwCYB2Aowu/Npfk5Op0RaT0iGqiWxJmtgvAuSvuvhvA62Z22MymAXwJwIcBHEOt4wUS9qcNGdPds2fPGZJHGnHuJdYAONPgxyiKa+W5XivPE9BzXfSOqz35nj37d5K3rEn46yszbsE+hB9e0QK1zvY9AD4F4E9IPgjga0kCaEina2aDjTjvUiR3N3sr5bxcK8/1WnmegJ5rPZlZHhvnhsYmzMwuAvj1NCfS8IKIyPKOAVi/5Od1AE5kOZE6XRGR5b0IYDPJTSQ7ADwM4KtZTlTmTjfJOEyruFae67XyPAE918IK7ZZjZrMAPgZgJ4ADAP7CzPZnOr+Z9pAUEclLma90RURKp/SdLsmPkzSSSaeMlA7J/0LyIMnvkXyG5Kpmx1RvTrVPyyG5nuS3SB4guZ/ko82OqdFIVkm+RPLZZsdSBKXudEmuB/ABAG82O5YGex7A7Wb246itQvPJJsdTV5Fqn1Y0C+B3zexHAfwUgN9q4ee66FHUxkEFJe90Afw3AL8HoKUHps3smwsD+QDwHfywAqZVeNU+LcfMTprZ3oX/HketMxpqblSNQ3IdgAcBfLbZsRRFaTtdktsAHDez7zY7lpz9BoCvNzuIOgtV+7RsR7SI5EYAdwB4obmRNNQfo3ZhNN/sQIqi0Es7kvzfANYGmv4AwO8D+Ll8I2qc2HM1s/+58Dt/gNo/T5ddPq5kgtU+uUeRI5I9AL4M4DEzG2t2PI1A8iEAp81sD8n3Njueoih0p2tm7w/dT/LHAGwC8N2FlYPWAdhL8m4zO5VjiHXjPddFJH8VwEMA7rfWm+dXt2qfMiC78MW4AAAAyklEQVTZjlqH+0Uz+0qz42mgewBsI/khACsB9JH8gpl9pMlxNVVLzNMl+QMAw2bWkguIkNwK4I8A/KyZjTQ7nnoj2YZagvB+AMdRq/755ayTz4uMtauEzwM4Z2aPNTuevCxc6X7czB5qdizNVtox3WvMnwDoBfA8yZdJfqbZAdVTPat9SuAeAL8C4L6F9/LlhStBuUa0xJWuiEhZ6EpXRCRH6nRFRHKkTldEJEfqdEVEcqROV0QkR+p0RURypE5XRCRH6nRFRHL0/wAmEytLYX+WGwAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAAD8CAYAAADUv3dIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3XuMXdd1HvDvu3dmyHlzRI5EaUiatENJoZQ4ikZyUiGKLdkRbSl0mraIFDjIq2YLxIlUxAjspID6T4GmLdLUiBuDsBQbsCMjka3UVmXTamKXyMOKSEq2SZESVcoUn+LwNQ9yhvNa/ePO1BNqrz3nHN577jmX38+4sObuOeeu+9pzuNdee9PMICIi+ag0OwARkWuJOl0RkRyp0xURyZE6XRGRHKnTFRHJkTpdEZEcqdMVEcmROl0RkRyp0xURyVFbI066Zs0a27hxYyNOLbLEVKRtZW5RSHZ79uw5Y2aDV3OOaueNZnOXE/2uzZzfaWZbr+bxrlZDOt2NGzdi9+7djTi1yBKvRdpuzi0KyY7kkas9h81dxoq1DyT63amjX7qV5NLOaYeZ7bjaGNJoSKcrIpIbEmTikdIzZjbcyHCWo05XREqNICosT1eW6M8DyUdJ7iO5n+RjjQ5KRCQNspLoVgTL/nkgeTuAjwK4G8A0gG+Q/F9mdqjRwUlrGZ3e6bb1dyQbk2sdGo+uJ5LNDiGxJF3/jwL4jpldMrNZAP8HwD9vbFgiIkkRta4syQ1rSO5ectued7RJBkL2AfiPJFcDmATwIQBvm5qwEPx2ANiwYUM9YxQRiWqpRJqZHSD5hwCeBzAB4LsAZgO/twPADgAYHh7WdhQikgsyVafbdIkiNbMnzOwnzexeAOcAaDxXRAqiNnshya0IEkVB8nozO01yA4BfBPDTjQ1LRCSpVPN0my5p1//lhTHdGQC/ZWbnGxhTCRUlE+3FkTWG2PMKG51+w23LNkMh62ubPvZ83yvNUKinFJ3umlJUpJnZzzQ6EBGRLIhagURCxU+kiYgUW2sOL4iIFBOBSqU8XVl5IhURCVosjigHdbp1kTWhU+9kSvPPNzZ90G07fvFrqc831N3htvX7TXjl/KupH2vLgN9W/wSh1JOGF0REcsJ0Y7rlmL0gIlJkTD68oNkLIiJXS8MLIiJ5IVGpVJsdRWLqdEWk1GrFEbrSlf+vCKWq/uMcnfBnG6zv2ea2vTjybPD+8Rn/imNz35zbdmoy/KUZm/Z3eY3NlIBTobRl4Bb3iPgMhU2Rxyp6yXGrU3GEiEiu1OmKiOSGaYYXNGVMROSqEGDyMmBNGRMRuRq14ojybEypTrfBsu2A6ydmYufLYtcpv5b2jtV+2e63Tq4I3v/Qej/xdWjMT7KdvBRu626bcY/5+9OROmDHS2cPu213rPYfC/CTbJ548i1Gibm0yjR7IVGkJP8dyf0k95F8iuTKRgcmIpIUWUl0K4JloyA5BOB3AAyb2e0AqgAebnRgIiLJcHF3yuVvBZB0eKENQCfJGQBdAE40LiQRkRTKtbLj8qGa2XEA/xXAmwBOAhg1s29e+Xskt5PcTXL3yMhI/SMVEfFUKsluBZBkeGEAwIcBbAJwE4Bukh+58vfMbIeZDZvZ8ODgYP0jFRHxVBLeCiDJ8ML7AbxhZiMAQPIrAP4ZgC80MrBiCmeVs5ePhv3NiUNu29rOebfttdHw23nmsv9p++45fwbA4XF/tsE9N0wH7//P3+91j3lXb2x2QNhB5zkBQG+7/1p4hrrMbYvNhnj3dX7s3W3eOWOfiyyzDeq9q3OLzHggYMnHa0tRHPEmgJ8i2QVgEsD9AHbHDxERyVHyHFnxiyPM7AWSTwPYC2AWwEsAcv3LICISVSnGzIQkEs1eMLPHATze4FhERDIoznSwJFSRJiLlRgBVdbrXlFiyLJZk89aD3dyXLY6+jnBi6a+dkl0AuH6lv8btsUv+x+M/fa8zeH9HxU9UHRzxE3Nzs+H7e/v8L9NNnX7s3U6Sbe9ZP6m4uc9Plp285B/3LzZOBe9/bTSWfPNLrLcM/Lzb5suy63SeO1U3mK50RURyVJ4+V52uiJQc0XqJNBGRQitPn6tOV0RKjoRVC1JuloA6XREpP13pShLjM+FPSqwcdXLW/3TtORs+bmrOP+bIRLvbdnrMbcJKZ0XlI0f92Qs9vX4ck5Ph4y5f9s832ePPhpifC1/5VCJTiw6P+FdL79sYLnsGgM8f6grev67bn11x20CsJDo8s2Go2/9cxGbQHJ34avD+9T23RmIoGc1eEBHJkRJpIiI5IdIML5RiwRsRkWJLPrxQ/AVvREQKjVQZcPFlK3/0SnrHpv0dcE9NxqayhD8oRyZiu+b6b9mRiXDbtJ8DchNYAHD+nL9e7dykkySa9883dcxPHllX+o/ihcjVTcU5X39/5JjIF/cfz/il1F4Yq1deco8Zm/Y/F97OyFsGvN2jgdhnen3PtshxWRSwfFiJNBGRHJWnz1WnKyLlZgCsRLMXkuyRdgvJl5fcxkg+lkdwIiLLIlprC3YzexXATwAAySqA4wCeaXBcIiLJFaM/TSTt8ML9AP6vmR1pRDAiIukRaOG1Fx4G8FQjAslXLMMay8yGeeW8y/mOU+57esqfvfDmRf8tmxgPzxwYGfFnIbRFPgFzE5FSVedDXjl90T2kcnbSbbNIiat/jF/CjLPhuy+M+E94xVB4YXYAmJry32NvRsSuU/75Tl7yX9ufXRueDfPiyLPuMTf3R14LZ1fi+E7Vse9IwRY4T1cc0XSJ/zyQ7ACwDcBfOu3bSe4muXtkZKRe8YmILK/CZLcCSHNN/kEAe83srVCjme0ws2EzGx4cHKxPdCIiSZSo000zvPAIWmJoQURaCgErRn+aSKJOl2QXgA8A+DeNDUdEJINWS6SZ2SUAqxscS478ZFls9949Z5wtayOjNH/3lp8gWlENJ75ia9yOOskyABgdDSfM7C2/HHV2yntOQPWin+yh08YZfw1ZRB6Ll/w21zn/8sa6wq/h/ICzEDCA6Tf82OfXdrttHe3h9/8s/c/F+LT/uehxdjL+/nn/63pzv58sjSfMWgCLM3SQhCrSRKT8ynOhq05XRFpAQarNklCnKyLlpi3YRUTyZbrSLTq/omZs+qDb1uskTI5f9CvIbuzyExx/dSS8oWEk34QLF/xE2qyTB+KknxCrnvaTbIgktzjhLNI76z/f2NUIZ/01iT3W5g/ksSMcH89FquJW+Uk26/S/KqPV8HFm/mtR7fdjn45sJOr51H7/fPfccCh4/303PRg5YwHXzPUQQFtzOl2SvwDgQQDXA/i0mX1zuWNKNPwsIhKScIWxhFfDJJ8keZrkvivu30ryVZKvk/wEAJjZX5nZRwH8GoBfSnJ+dboiUn71rUj7HICtS+9YWGHx06hV5m4B8AjJLUt+5d8vtC8fatIoREQKiwlvCZjZLgDnrrj7bgCvm9lhM5sG8CUAH2bNHwL4upntTXL+a3RMV0RaBlPtHJF1C/YhAEeX/HwMwHsA/DaA9wPoJ/kjZvaZ5U6kTldEyi95p5t1C/bQA5iZfQrAp9KcSJ3uFfo6/F1fd50KzxzYfcYv6byUIRN9ccKfoXD5st+G4xPBu6MzFGKluef9TD+99WAjZcCxbP7svDPbIFJKW13hr1eLTqeUOrILL9r9WSjVN8fctvnp8HO+MOPHF8vpHOgKf54+cJP/fhyLzKC5c034a/7K+a/5QURsGYi1NmFmA5HHFuzHAKxf8vM6ACeynEhjuiJScqlmL6xZXPd74bY94YO8CGAzyU0La4s/DOCrWaLVla6IlF8dhxdIPgXgvah10McAPG5mT5D8GICdAKoAnjSz/VlCVacrIuVW5zJgM3vEuf85AM9d7fnV6YpI6bVcGTDJVQA+C+B2AAbgN8zsHxoZ2NXzyxhfOf+q23Zx1n/zbu4P3/+9c/76t0ciG0m+dd65/0RkjdvDF9w2eiW4sXVxY4m02MaUc+Hk0eRlZ0fIZczNhRNpHR19/jGx8ubL4fek2h5JvsWulub8BCZXht/jyrx/zFhHj9t2tjecapmMLFX809c7ZdkA/vKN8PnefZ3/fO8afMh/sIjR6Z3B+/s7Hsh0vkTSJdKyThmrm6RXuv8dwDfM7F8uDCKHFw0QEcldqmqzrFPG6mbZTpdkH4B7UastxkI1hv9nVUQkbyVa2jHJlLF3AhgB8GckXyL5WZL+3iUiInlKWgJckH45SafbBuAnAfypmd0B4CKAT1z5SyS3L859GxkZqXOYIiJhhloZcJIbss/TrZskY7rHABwzsxcWfn4agU53YTB6BwAMDw9HyqZEROos+eyF4o/pmtkpkkdJ3mJmrwK4H8ArjQ+tcWIzFMZn/LbD4+ln2F3X4Ze+7ht1HmvGP8ZW+OWelbcuBu93FxwHwHG/bX7GX1h8ejb8WDOzfqnqnFPqC/glwjNz/vnanMXDa23hcu7Oil+yzdEpt816Isc5r6H1+sdY5LLk4sVw42uj/vk6q/5re9tAeJbHzf3+rJs4f2ZQQ2cpePIpA66bpL3IbwP44sLMhcMAfr1xIYmIJEcAlRItaJCo0zWzlwE09ZJcRMRTotoIVaSJSMkl34kHKFFxhIhIQRFspURaMcR2Jk2vu83PYtw16K8Hun//D1I/1v4R/yWedUpp6azPCgCV0UhdilOqykhibnYyvAYvAMxGkmKXZ8aD909NO7XNiK+nW6mEX6fYMTHz8+Hy5raqXwbcZn5iLra2sJcV46ifiJxb609199ZMPnA229e10/m8j037r+2dazKtWoj1Pfmvp9uSY7oiIoVFILLWfeGo0xWR0lMiTUQkJ3VeTrfh1OmKSOlp9oKISI5SdLqavXD10mdLe9sPum1HJ/y2zrZwaen+C3555oULkZkDU+G2irfTLgBejJT0eguSRxYqn5v3H8uboQAAs3PhHYZjsw1iZcBeW+x8sZ2CvVkK05Hn5M2gAIBqpGzXIrsIe3jBn9lQ6Q/H7pUHA8DUqvT/vh7q9mfJrO+51W0bnX4jctZ0M43uvPO2O1MdEEKg0oJlwCIihUQokSYikp90FWlNp05XREpPna6ISI40Zazu0ifLjk5kK2M8NeknZw6Nhl+utZ1+QuLNtkipjPdJiZQBm7PzLADwjFOqGtnJNmbesiXgPPGS3nCMlYq/5mvsfPNOYi4WN2MbqXg7LQOgk/hkp59gi+3CfHEi/FqsGvB7lk29/vN693X1XU+3v2NTpDXdd3XPnv17MgWxRMoxXU0ZExG5KulmL5RjyhjJHwAYBzAHYLbZQYuILNWqY7rvM7MzDYtERCSjVu10RUQKp2zzdJMuiGYAvklyTzO2LBYRcbGWk05yK4KkV7r3mNkJktcDeJ7kQTPbtfQXFjrj7QCwYcOGOoeZn28cC5f6AsA6p2wyVgZcjbzC1bbwpyA6Q+GyP7MhiwojuwvTj8M7bh5+Vr7eYmXFXuzV2GwIRGZXzERe93lndkjk8iv2Hledt2RVpNT3wrR//fStk+HPZ3ebX4rc73+ko2XA/R35L2IOAJX0ldhNk+hK18xOLPz/aQDPALg78Ds7zGzYzIYHBwfrG6WIiGNxeCHJrQiW7XRJdpPsXfxvAD8HYF+jAxMRSYQAyUS3IkgyvHADgGcWAm4D8Odm9o2GRiUikkJB+tNElu10zewwgHfnEIuISCaqSMMU/HU16z3QXt+dgn/nNj+Z8h/2hpMws+a/4yv9DWaxYkX4uKnI7r1RXnJmIpJwiqwhG2vzVCt+BiZatuuUHMfOF42j6idEPdEy4NiauU6pt/VGYo+Uh7c5D7W2y0/mdUUW/I1UI7ti60rH1tptFi1iLiKSEzL6N6xw1OmKSKnVNqbMtqhTM6jTFZHSK0rhQxLqdEWk9Eo0utCMTjefBNv6nm1u2+j0Trdtzxm/omp4TfifMOMz/lveFRlsGjkdPl+sWmm+308QVSaddV0jy97FkkexarVqNZIhdMTW560yfcKsva079TGxxFyl3X9trSuy9qyF38fYmrmxzUIrlXAcp6f892plJJH24856ujHjM7FLxyzf1fD3vh4bU2p4QUQkZxpeEBHJCQk4y5gUkjpdESk9anhBRCQftTHdZkeRnDpdESk9zV7AStS/3NfjPY5fHtzf8YDbtrnP30X48Li3Rqv/T5vzlyOzAypOWWd7xo+QU6pqHZE1c2f9jH3HfG/qEGbn/DVaO9r983klwqT/WsTa2qudwfvb2sL3LwTht0VmocyvCs/kmI+VAUdmQ3R2pb9s+8BNU27bjZHyYc9Qd2w2SZbS+/D3tD67AZtmL4iI5ClFIq1VF7wREckH023FowVvRESuloYXRERy0rKzF0hWAewGcNzMHmpcSGmFB/Vjm+cBsbb0Rqb8RFVvu/8XuLsnnJy5fMo/Zn61nwiiVwbcG1lbdtZ/rPa5Hv84R1tbl/9Qs5fcNi+RVq36CZ1YCfOKjv7wMV2RUt9IwhGRUmp4x0XKuVes9hNp/f3hx4qtmRuztjP82sY+m9k1aWPKpjxqNmmudB8FcABAX4NiERHJpEzDC4n+QJBcB+BBAJ9tbDgiIuksLmKe5FYEScP4YwC/B8Ddb4XkdpK7Se4eGRmpS3AiIsshah1ZklsRJNmC/SEAp80sOonZzHaY2bCZDQ8ODtYtQBGR5VRoiW5FkGRM9x4A20h+CLVSsz6SXzCzjzQ2NBGRZFpq9oKZfRLAJwGA5HsBfLxYHW44W9rfkS2Levzi19y2NSvCoyvvW+uXYL425r/EU3PhzLy9y58BcP51fwaAt42s9UVKOiOlr5EqW7TDmdkw7+/4GyvbrVYii4R7x8QWUl/pvBaxmRyR2Qvz1/mPZc5jYa2/yLq3EzTgvyW/8A7/ve9u89/HU5Ph133LwGb3mDJZHF4oC83TFZHSa6kr3aXM7NsAvt2QSEREMiDji04Vja50RaT0NLwgIpITLe1Ycl7SAQDuXBMusz160U/AXL/SX8t0ej58volJP6k0dr2f0JmfSb9uavUHo26brfCfF3vDj8XRyHq6iCSxvAQcIwmnvlhJr/M+OmsOA4BF1r+dXxV5LCeOrsi6uLG23o70HchQt//e3zXoVe1nWRcXaFapb0zLjumKiBSROl0RkZwQQHuJhhfKNP4sIvI2i4uYJ7nV/7H5TpJPkHw66THqdEWk9OrZ6ZJ8kuRpkvuuuH8ryVdJvk7yEwBgZofN7DdTxZrml0VEioaoLXec5JbQ5wBs/SePUVtP/NMAPghgC4BHSG7JEm/LjumOTu902/o7Nrlt993kl0a+OBLO9t42EJ6FAABj0/7ftR8bmA3ef/C8P3uht8f/5Jx3FjhvWxnZyfZSOAYA4Jg/EwEd/nEei+xyzDlnTG7eH6uLLTpuA84sj2k/yz+33l8q2i31BdA9GJ71sP4m//lu6vU/M+9y2k5e8s/3rzb5n5mjE+Edrvs6/BkZsR2zi6ieQwdmtovkxivuvhvA62Z2GABIfgnAhwG8kvb8utIVkVKrbdeTeJWxNYtL0C7ctid8mCEAR5f8fAzAEMnVJD8D4A6Sn0xyopa90hWRawMJtDd+N+DQI5iZnQXwb9OcSJ2uiJReDvN0jwFYv+TndQBOZDmROl0RKb0cyoBfBLCZ5CYAxwE8DOCXs5yoZTvdWLIsXsbol0beNRg+7pXzr7rHeDuxAsCzR8OJjHtv9Nfn3QW/DNhbo3VkxI9hbmN411wAqJyccNu8VHDlhH+MRXbHZSTB5Z4vUrZrnek/2tbtJ6NW9vmJtJ7u8GuxqsN/3e9aM+22ees2e2XoAHD8YqSs2Hla8e9IVt73p3Glw4uzFxJaQ3L3kp93mNmOf3I+8ikA71343WMAHjezJ0h+DMBOAFUAT5rZ/izxtmynKyLXjhTDC8uO6ZrZI879zwF4Ll1kb7dsp0tyJYBdAFYs/P7TZvb41T6wiEg9LO4GXBZJrnQvA7jPzCZItgP4W5JfN7PvNDg2EZFl1YYXEo/pLju80GhJ9kgzAIsDde0Lt/KsLiEiLS/FhW7WKWN1kyhWklWSLwM4DeB5M3uhsWGJiCRTK45ozoI3WSRKpJnZHICfILkKwDMkbzezKxeD2A5gOwBs2LCh7oGml99Cy0Pdfhb9tVE/4+w5PeVnym+NlBzvmw2nqd8TqRB/6fXIJ/GdvW7T5cvhf+zMOqXIAMBxP2PvfiO88mDEdzn2Sp+rkcuMzk7/tejr9w+8risc48/c4M9COXfZf6wHhsLv8Z4z/uyK2MyG9T23Oi3ZZvHEj2vOAudF6VCTSDX8bGYXUNuYcmugbYeZDZvZ8ODgYJ3CExGJIw3VhLciWLbTJTm4cIULkp0A3g/gYKMDExFJgqjNXkhyQ/a1F+omyfDCjQA+v7C0WQXAX5jZs40NS0QkuXrO0220JLMXvgfgjhxiERFJLWVFWtOpIu1tsiYXwrzSYQBY2xkepRmf8dex/esT/hqo67rCa9zGEnPXrY6U0po/BjY+Hr6/o8P/SE10+aNZbc4yUXOzfgxd3elnxEc2F47u0Luuzy9THnR2fJ6MVDYPdfklwt6O1LFkWWxt3GzJreLt+OtiLmsv1I06XREpvRIVpKnTFZFyW5ynm1DxK9JERIqMANoriYcXip9IExEpujIVR6jTFZFSY4FKfJNo4U43axljTPi4/o5sMx688szYouixnYf/7q3wTITrnew6ANy7zp8p8Y9n/Ix4X4aFu88M+LMovOMmZiIzL1b4z+vSbDi1cqMzwwMAuqr+P1F/fsOk23Z4PPw1+te3+IuEx97j3vZwHH45LzA6/Ybb5mvEd6Q5lEgTEclRbCpg0ajTFZFS0+wFEZGclWk9XXW6IlJ6VEVaERQ/EXB0IlwGvGXAT5j0tvsLvJ28FE4s3djlJ5zGpv1rhF/dfMlt+/yhruD9HZFk1ECkHPn2VeEEoZekAoDxGT/2d3SH1+7tafcTfb+22U+Wxday9XbvjYmtwdzf8UDq88WTuZ7if0eSKtGQbit3uiJyLSCUSBMRyVWJ+lx1uiJScizX0o5Jdo5YT/JbJA+Q3E/y0TwCExFJYnF4IckNJdk5YhbA75rZXpK9APaQfN7MXmlwbC3CT1as70l/zPiMX8n00Ibwn/v+js3uMX9z4pDbFrO5P1zZdWTCT5bde4Nf/Xbucvjvf6zqbHhNZKNLxx2r/Yq+8Rn/cmmo24/DWzPZS5QCwPqebW7b0YmvOsf4CdZWSoplkeJCt+lTxpa90jWzk2a2d+G/xwEcADDU6MBERJJiwlsRpBrTJbkRta17XmhEMCIiWZRpwZvEhRwkewB8GcBjZjYWaN++OE4yMjJSzxhFRFxJr3KL0i8n6nRJtqPW4X7RzL4S+h0z22Fmw2Y2PDg4WM8YRUSiKrREtyJYdniBJAE8AeCAmf1R40MSEUnhhzMTSiHJmO49AH4FwPdJvrxw3++b2XONC+takU/G+cURf93UtZ3+X/8tA7e4bUPd4fVb+zs2uMfE1nwdm54K3n9ozJ8NEeOtSXtx1v92xnZujsXutcVnG/hiMxvk7YgWW0/XzP4WxRkOERF5m1a70hURKbQUfa7W0xURuVoppow1vThCna6IlFrKnSOaTp1uU3kJLj+hE0tueWIJovjmhL6x6XBJb7+/TGwm9930YKQ1v40Vs61XK3kpUZ+rTldEys60c4SISJ50pSsikhO2YHGEiEihZSuhaQ51uiJSerrSlYTqvYOrl83PNkMhvgC71+Y/VmyX2/6OesdedPnNvGh9RVpDbHnqdEWk1GpdrjpdEZHckOVZ8kadroi0AF3piojkhGDyxR214I3UU70TMFmSWFljSJ+Yi61x65cjZy2Jrvdrq2RZPaUYXmj6gjfLRkrySZKnSe7LIyARkfTKs0takj8PnwOwtcFxiIhkwhT/K4IkO0fsWth6XUSkkIrSoSahMV0RKT2yPIXAdZvcRnI7yd0kd4+MjNTrtCIiy0g6nluMq+G6XekuTLvYAQDDw8PlWdxSIoqQYfdjyLawuMpvW5GGF0REclWeirQkU8aeAvAPAG4heYzkbzY+LBGR5Fpt9sIjeQQiIpIFSbBEaztqeEFESo8lWsZcna5cY5Qsa0260hURyYmGF0REcqZOV0QkNymWdmw6dboi0gJ0pSsikguCqGi7HmkNKpmVslCnKyKSm2ZVm5HsBvA/AEwD+LaZfXG5Y8rz50FEJKi+q4x5u+WQ3EryVZKvk/zEwt2/COBpM/sogG1Jzq9OV0RKb7EUeLlbQp/DFbvlsLZg76cBfBDAFgCPkNwCYB2Aowu/Npfk5Op0RaT0iGqiWxJmtgvAuSvuvhvA62Z22MymAXwJwIcBHEOt4wUS9qcNGdPds2fPGZJHGnHuJdYAONPgxyiKa+W5XivPE9BzXfSOqz35nj37d5K3rEn46yszbsE+hB9e0QK1zvY9AD4F4E9IPgjga0kCaEina2aDjTjvUiR3N3sr5bxcK8/1WnmegJ5rPZlZHhvnhsYmzMwuAvj1NCfS8IKIyPKOAVi/5Od1AE5kOZE6XRGR5b0IYDPJTSQ7ADwM4KtZTlTmTjfJOEyruFae67XyPAE918IK7ZZjZrMAPgZgJ4ADAP7CzPZnOr+Z9pAUEclLma90RURKp/SdLsmPkzSSSaeMlA7J/0LyIMnvkXyG5Kpmx1RvTrVPyyG5nuS3SB4guZ/ko82OqdFIVkm+RPLZZsdSBKXudEmuB/ABAG82O5YGex7A7Wb246itQvPJJsdTV5Fqn1Y0C+B3zexHAfwUgN9q4ee66FHUxkEFJe90Afw3AL8HoKUHps3smwsD+QDwHfywAqZVeNU+LcfMTprZ3oX/HketMxpqblSNQ3IdgAcBfLbZsRRFaTtdktsAHDez7zY7lpz9BoCvNzuIOgtV+7RsR7SI5EYAdwB4obmRNNQfo3ZhNN/sQIqi0Es7kvzfANYGmv4AwO8D+Ll8I2qc2HM1s/+58Dt/gNo/T5ddPq5kgtU+uUeRI5I9AL4M4DEzG2t2PI1A8iEAp81sD8n3Njueoih0p2tm7w/dT/LHAGwC8N2FlYPWAdhL8m4zO5VjiHXjPddFJH8VwEMA7rfWm+dXt2qfMiC78MW4AAAAyklEQVTZjlqH+0Uz+0qz42mgewBsI/khACsB9JH8gpl9pMlxNVVLzNMl+QMAw2bWkguIkNwK4I8A/KyZjTQ7nnoj2YZagvB+AMdRq/755ayTz4uMtauEzwM4Z2aPNTuevCxc6X7czB5qdizNVtox3WvMnwDoBfA8yZdJfqbZAdVTPat9SuAeAL8C4L6F9/LlhStBuUa0xJWuiEhZ6EpXRCRH6nRFRHKkTldEJEfqdEVEcqROV0QkR+p0RURypE5XRCRH6nRFRHL0/wAmEytLYX+WGwAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 2 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -638,7 +640,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.1.0\n"
+      "2.2.2\n"
      ]
     }
    ],
@@ -655,7 +657,7 @@
     {
      "data": {
       "application/vnd.vegalite.v2+json": {
-       "$schema": "https://vega.github.io/schema/vega-lite/v2.4.3.json",
+       "$schema": "https://vega.github.io/schema/vega-lite/v2.6.0.json",
        "config": {
         "view": {
          "height": 300,
@@ -663,7 +665,10 @@
         }
        },
        "data": {
-        "values": [
+        "name": "data-f02450ab61490a1363517a0190416235"
+       },
+       "datasets": {
+        "data-f02450ab61490a1363517a0190416235": [
          {
           "Acceleration": 12,
           "Cylinders": 8,
@@ -673,7 +678,7 @@
           "Name": "chevrolet chevelle malibu",
           "Origin": "USA",
           "Weight_in_lbs": 3504,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 11.5,
@@ -684,7 +689,7 @@
           "Name": "buick skylark 320",
           "Origin": "USA",
           "Weight_in_lbs": 3693,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 11,
@@ -695,7 +700,7 @@
           "Name": "plymouth satellite",
           "Origin": "USA",
           "Weight_in_lbs": 3436,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 12,
@@ -706,7 +711,7 @@
           "Name": "amc rebel sst",
           "Origin": "USA",
           "Weight_in_lbs": 3433,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 10.5,
@@ -717,7 +722,7 @@
           "Name": "ford torino",
           "Origin": "USA",
           "Weight_in_lbs": 3449,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 10,
@@ -728,7 +733,7 @@
           "Name": "ford galaxie 500",
           "Origin": "USA",
           "Weight_in_lbs": 4341,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 9,
@@ -739,7 +744,7 @@
           "Name": "chevrolet impala",
           "Origin": "USA",
           "Weight_in_lbs": 4354,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 8.5,
@@ -750,7 +755,7 @@
           "Name": "plymouth fury iii",
           "Origin": "USA",
           "Weight_in_lbs": 4312,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 10,
@@ -761,7 +766,7 @@
           "Name": "pontiac catalina",
           "Origin": "USA",
           "Weight_in_lbs": 4425,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 8.5,
@@ -772,7 +777,7 @@
           "Name": "amc ambassador dpl",
           "Origin": "USA",
           "Weight_in_lbs": 3850,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 17.5,
@@ -783,7 +788,7 @@
           "Name": "citroen ds-21 pallas",
           "Origin": "Europe",
           "Weight_in_lbs": 3090,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 11.5,
@@ -794,7 +799,7 @@
           "Name": "chevrolet chevelle concours (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4142,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 11,
@@ -805,7 +810,7 @@
           "Name": "ford torino (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4034,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 10.5,
@@ -816,7 +821,7 @@
           "Name": "plymouth satellite (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4166,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 11,
@@ -827,7 +832,7 @@
           "Name": "amc rebel sst (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 3850,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 10,
@@ -838,7 +843,7 @@
           "Name": "dodge challenger se",
           "Origin": "USA",
           "Weight_in_lbs": 3563,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 8,
@@ -849,7 +854,7 @@
           "Name": "plymouth 'cuda 340",
           "Origin": "USA",
           "Weight_in_lbs": 3609,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 8,
@@ -860,7 +865,7 @@
           "Name": "ford mustang boss 302",
           "Origin": "USA",
           "Weight_in_lbs": 3353,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 9.5,
@@ -871,7 +876,7 @@
           "Name": "chevrolet monte carlo",
           "Origin": "USA",
           "Weight_in_lbs": 3761,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 10,
@@ -882,7 +887,7 @@
           "Name": "buick estate wagon (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 3086,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -893,7 +898,7 @@
           "Name": "toyota corona mark ii",
           "Origin": "Japan",
           "Weight_in_lbs": 2372,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -904,7 +909,7 @@
           "Name": "plymouth duster",
           "Origin": "USA",
           "Weight_in_lbs": 2833,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -915,7 +920,7 @@
           "Name": "amc hornet",
           "Origin": "USA",
           "Weight_in_lbs": 2774,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -926,7 +931,7 @@
           "Name": "ford maverick",
           "Origin": "USA",
           "Weight_in_lbs": 2587,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -937,7 +942,7 @@
           "Name": "datsun pl510",
           "Origin": "Japan",
           "Weight_in_lbs": 2130,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 20.5,
@@ -948,7 +953,7 @@
           "Name": "volkswagen 1131 deluxe sedan",
           "Origin": "Europe",
           "Weight_in_lbs": 1835,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 17.5,
@@ -959,7 +964,7 @@
           "Name": "peugeot 504",
           "Origin": "Europe",
           "Weight_in_lbs": 2672,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -970,7 +975,7 @@
           "Name": "audi 100 ls",
           "Origin": "Europe",
           "Weight_in_lbs": 2430,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 17.5,
@@ -981,7 +986,7 @@
           "Name": "saab 99e",
           "Origin": "Europe",
           "Weight_in_lbs": 2375,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 12.5,
@@ -992,7 +997,7 @@
           "Name": "bmw 2002",
           "Origin": "Europe",
           "Weight_in_lbs": 2234,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -1003,7 +1008,7 @@
           "Name": "amc gremlin",
           "Origin": "USA",
           "Weight_in_lbs": 2648,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -1014,7 +1019,7 @@
           "Name": "ford f250",
           "Origin": "USA",
           "Weight_in_lbs": 4615,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -1025,7 +1030,7 @@
           "Name": "chevy c20",
           "Origin": "USA",
           "Weight_in_lbs": 4376,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -1036,7 +1041,7 @@
           "Name": "dodge d200",
           "Origin": "USA",
           "Weight_in_lbs": 4382,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 18.5,
@@ -1047,7 +1052,7 @@
           "Name": "hi 1200d",
           "Origin": "USA",
           "Weight_in_lbs": 4732,
-          "Year": "1970-01-01"
+          "Year": "1970-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -1058,7 +1063,7 @@
           "Name": "datsun pl510",
           "Origin": "Japan",
           "Weight_in_lbs": 2130,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -1069,7 +1074,7 @@
           "Name": "chevrolet vega 2300",
           "Origin": "USA",
           "Weight_in_lbs": 2264,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -1080,7 +1085,7 @@
           "Name": "toyota corona",
           "Origin": "Japan",
           "Weight_in_lbs": 2228,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -1091,7 +1096,7 @@
           "Name": "ford pinto",
           "Origin": "USA",
           "Weight_in_lbs": 2046,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 20,
@@ -1102,7 +1107,7 @@
           "Name": "volkswagen super beetle 117",
           "Origin": "Europe",
           "Weight_in_lbs": 1978,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -1113,7 +1118,7 @@
           "Name": "amc gremlin",
           "Origin": "USA",
           "Weight_in_lbs": 2634,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -1124,7 +1129,7 @@
           "Name": "plymouth satellite custom",
           "Origin": "USA",
           "Weight_in_lbs": 3439,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -1135,7 +1140,7 @@
           "Name": "chevrolet chevelle malibu",
           "Origin": "USA",
           "Weight_in_lbs": 3329,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -1146,7 +1151,7 @@
           "Name": "ford torino 500",
           "Origin": "USA",
           "Weight_in_lbs": 3302,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -1157,7 +1162,7 @@
           "Name": "amc matador",
           "Origin": "USA",
           "Weight_in_lbs": 3288,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 12,
@@ -1168,7 +1173,7 @@
           "Name": "chevrolet impala",
           "Origin": "USA",
           "Weight_in_lbs": 4209,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 11.5,
@@ -1179,7 +1184,7 @@
           "Name": "pontiac catalina brougham",
           "Origin": "USA",
           "Weight_in_lbs": 4464,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -1190,7 +1195,7 @@
           "Name": "ford galaxie 500",
           "Origin": "USA",
           "Weight_in_lbs": 4154,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -1201,7 +1206,7 @@
           "Name": "plymouth fury iii",
           "Origin": "USA",
           "Weight_in_lbs": 4096,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 11.5,
@@ -1212,7 +1217,7 @@
           "Name": "dodge monaco (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4955,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 12,
@@ -1223,7 +1228,7 @@
           "Name": "ford country squire (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4746,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 12,
@@ -1234,7 +1239,7 @@
           "Name": "pontiac safari (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 5140,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -1245,7 +1250,7 @@
           "Name": "amc hornet sportabout (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 2962,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -1256,7 +1261,7 @@
           "Name": "chevrolet vega (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 2408,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -1267,7 +1272,7 @@
           "Name": "pontiac firebird",
           "Origin": "USA",
           "Weight_in_lbs": 3282,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -1278,7 +1283,7 @@
           "Name": "ford mustang",
           "Origin": "USA",
           "Weight_in_lbs": 3139,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -1289,7 +1294,7 @@
           "Name": "mercury capri 2000",
           "Origin": "USA",
           "Weight_in_lbs": 2220,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -1300,7 +1305,7 @@
           "Name": "opel 1900",
           "Origin": "Europe",
           "Weight_in_lbs": 2123,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 19.5,
@@ -1311,7 +1316,7 @@
           "Name": "peugeot 304",
           "Origin": "Europe",
           "Weight_in_lbs": 2074,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -1322,7 +1327,7 @@
           "Name": "fiat 124b",
           "Origin": "Europe",
           "Weight_in_lbs": 2065,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -1333,7 +1338,7 @@
           "Name": "toyota corolla 1200",
           "Origin": "Japan",
           "Weight_in_lbs": 1773,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 18,
@@ -1344,7 +1349,7 @@
           "Name": "datsun 1200",
           "Origin": "Japan",
           "Weight_in_lbs": 1613,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -1355,7 +1360,7 @@
           "Name": "volkswagen model 111",
           "Origin": "Europe",
           "Weight_in_lbs": 1834,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 20.5,
@@ -1366,7 +1371,7 @@
           "Name": "plymouth cricket",
           "Origin": "USA",
           "Weight_in_lbs": 1955,
-          "Year": "1971-01-01"
+          "Year": "1971-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -1377,7 +1382,7 @@
           "Name": "toyota corona hardtop",
           "Origin": "Japan",
           "Weight_in_lbs": 2278,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -1388,7 +1393,7 @@
           "Name": "dodge colt hardtop",
           "Origin": "USA",
           "Weight_in_lbs": 2126,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 23.5,
@@ -1399,7 +1404,7 @@
           "Name": "volkswagen type 3",
           "Origin": "Europe",
           "Weight_in_lbs": 2254,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 19.5,
@@ -1410,7 +1415,7 @@
           "Name": "chevrolet vega",
           "Origin": "USA",
           "Weight_in_lbs": 2408,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -1421,7 +1426,7 @@
           "Name": "ford pinto runabout",
           "Origin": "USA",
           "Weight_in_lbs": 2226,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 12,
@@ -1432,7 +1437,7 @@
           "Name": "chevrolet impala",
           "Origin": "USA",
           "Weight_in_lbs": 4274,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 12,
@@ -1443,7 +1448,7 @@
           "Name": "pontiac catalina",
           "Origin": "USA",
           "Weight_in_lbs": 4385,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -1454,7 +1459,7 @@
           "Name": "plymouth fury iii",
           "Origin": "USA",
           "Weight_in_lbs": 4135,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -1465,7 +1470,7 @@
           "Name": "ford galaxie 500",
           "Origin": "USA",
           "Weight_in_lbs": 4129,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 11.5,
@@ -1476,7 +1481,7 @@
           "Name": "amc ambassador sst",
           "Origin": "USA",
           "Weight_in_lbs": 3672,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 11,
@@ -1487,7 +1492,7 @@
           "Name": "mercury marquis",
           "Origin": "USA",
           "Weight_in_lbs": 4633,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -1498,7 +1503,7 @@
           "Name": "buick lesabre custom",
           "Origin": "USA",
           "Weight_in_lbs": 4502,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -1509,7 +1514,7 @@
           "Name": "oldsmobile delta 88 royale",
           "Origin": "USA",
           "Weight_in_lbs": 4456,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 12.5,
@@ -1520,7 +1525,7 @@
           "Name": "chrysler newport royal",
           "Origin": "USA",
           "Weight_in_lbs": 4422,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -1531,7 +1536,7 @@
           "Name": "mazda rx2 coupe",
           "Origin": "Japan",
           "Weight_in_lbs": 2330,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 12.5,
@@ -1542,7 +1547,7 @@
           "Name": "amc matador (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 3892,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -1553,7 +1558,7 @@
           "Name": "chevrolet chevelle concours (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4098,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -1564,7 +1569,7 @@
           "Name": "ford gran torino (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4294,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -1575,7 +1580,7 @@
           "Name": "plymouth satellite custom (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4077,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -1586,7 +1591,7 @@
           "Name": "volvo 145e (sw)",
           "Origin": "Europe",
           "Weight_in_lbs": 2933,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 18,
@@ -1597,7 +1602,7 @@
           "Name": "volkswagen 411 (sw)",
           "Origin": "Europe",
           "Weight_in_lbs": 2511,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 19.5,
@@ -1608,7 +1613,7 @@
           "Name": "peugeot 504 (sw)",
           "Origin": "Europe",
           "Weight_in_lbs": 2979,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 18,
@@ -1619,7 +1624,7 @@
           "Name": "renault 12 (sw)",
           "Origin": "Europe",
           "Weight_in_lbs": 2189,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -1630,7 +1635,7 @@
           "Name": "ford pinto (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 2395,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -1641,7 +1646,7 @@
           "Name": "datsun 510 (sw)",
           "Origin": "Japan",
           "Weight_in_lbs": 2288,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -1652,7 +1657,7 @@
           "Name": "toyouta corona mark ii (sw)",
           "Origin": "Japan",
           "Weight_in_lbs": 2506,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -1663,7 +1668,7 @@
           "Name": "dodge colt (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 2164,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -1674,7 +1679,7 @@
           "Name": "toyota corolla 1600 (sw)",
           "Origin": "Japan",
           "Weight_in_lbs": 2100,
-          "Year": "1972-01-01"
+          "Year": "1972-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -1685,7 +1690,7 @@
           "Name": "buick century 350",
           "Origin": "USA",
           "Weight_in_lbs": 4100,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 11.5,
@@ -1696,7 +1701,7 @@
           "Name": "amc matador",
           "Origin": "USA",
           "Weight_in_lbs": 3672,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -1707,7 +1712,7 @@
           "Name": "chevrolet malibu",
           "Origin": "USA",
           "Weight_in_lbs": 3988,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -1718,7 +1723,7 @@
           "Name": "ford gran torino",
           "Origin": "USA",
           "Weight_in_lbs": 4042,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 12.5,
@@ -1729,7 +1734,7 @@
           "Name": "dodge coronet custom",
           "Origin": "USA",
           "Weight_in_lbs": 3777,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 11.5,
@@ -1740,7 +1745,7 @@
           "Name": "mercury marquis brougham",
           "Origin": "USA",
           "Weight_in_lbs": 4952,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 12,
@@ -1751,7 +1756,7 @@
           "Name": "chevrolet caprice classic",
           "Origin": "USA",
           "Weight_in_lbs": 4464,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -1762,7 +1767,7 @@
           "Name": "ford ltd",
           "Origin": "USA",
           "Weight_in_lbs": 4363,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -1773,7 +1778,7 @@
           "Name": "plymouth fury gran sedan",
           "Origin": "USA",
           "Weight_in_lbs": 4237,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 11,
@@ -1784,7 +1789,7 @@
           "Name": "chrysler new yorker brougham",
           "Origin": "USA",
           "Weight_in_lbs": 4735,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 11,
@@ -1795,7 +1800,7 @@
           "Name": "buick electra 225 custom",
           "Origin": "USA",
           "Weight_in_lbs": 4951,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 11,
@@ -1806,7 +1811,7 @@
           "Name": "amc ambassador brougham",
           "Origin": "USA",
           "Weight_in_lbs": 3821,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -1817,7 +1822,7 @@
           "Name": "plymouth valiant",
           "Origin": "USA",
           "Weight_in_lbs": 3121,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 18,
@@ -1828,7 +1833,7 @@
           "Name": "chevrolet nova custom",
           "Origin": "USA",
           "Weight_in_lbs": 3278,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -1839,7 +1844,7 @@
           "Name": "amc hornet",
           "Origin": "USA",
           "Weight_in_lbs": 2945,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -1850,7 +1855,7 @@
           "Name": "ford maverick",
           "Origin": "USA",
           "Weight_in_lbs": 3021,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -1861,7 +1866,7 @@
           "Name": "plymouth duster",
           "Origin": "USA",
           "Weight_in_lbs": 2904,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 21,
@@ -1872,7 +1877,7 @@
           "Name": "volkswagen super beetle",
           "Origin": "Europe",
           "Weight_in_lbs": 1950,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -1883,7 +1888,7 @@
           "Name": "chevrolet impala",
           "Origin": "USA",
           "Weight_in_lbs": 4997,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 12.5,
@@ -1894,7 +1899,7 @@
           "Name": "ford country",
           "Origin": "USA",
           "Weight_in_lbs": 4906,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -1905,7 +1910,7 @@
           "Name": "plymouth custom suburb",
           "Origin": "USA",
           "Weight_in_lbs": 4654,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 12.5,
@@ -1916,7 +1921,7 @@
           "Name": "oldsmobile vista cruiser",
           "Origin": "USA",
           "Weight_in_lbs": 4499,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -1927,7 +1932,7 @@
           "Name": "amc gremlin",
           "Origin": "USA",
           "Weight_in_lbs": 2789,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -1938,7 +1943,7 @@
           "Name": "toyota carina",
           "Origin": "Japan",
           "Weight_in_lbs": 2279,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 19.5,
@@ -1949,7 +1954,7 @@
           "Name": "chevrolet vega",
           "Origin": "USA",
           "Weight_in_lbs": 2401,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -1960,7 +1965,7 @@
           "Name": "datsun 610",
           "Origin": "Japan",
           "Weight_in_lbs": 2379,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -1971,7 +1976,7 @@
           "Name": "maxda rx3",
           "Origin": "Japan",
           "Weight_in_lbs": 2124,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 18.5,
@@ -1982,7 +1987,7 @@
           "Name": "ford pinto",
           "Origin": "USA",
           "Weight_in_lbs": 2310,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -1993,7 +1998,7 @@
           "Name": "mercury capri v6",
           "Origin": "USA",
           "Weight_in_lbs": 2472,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -2004,7 +2009,7 @@
           "Name": "fiat 124 sport coupe",
           "Origin": "Europe",
           "Weight_in_lbs": 2265,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -2015,7 +2020,7 @@
           "Name": "chevrolet monte carlo s",
           "Origin": "USA",
           "Weight_in_lbs": 4082,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 9.5,
@@ -2026,7 +2031,7 @@
           "Name": "pontiac grand prix",
           "Origin": "USA",
           "Weight_in_lbs": 4278,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 19.5,
@@ -2037,7 +2042,7 @@
           "Name": "fiat 128",
           "Origin": "Europe",
           "Weight_in_lbs": 1867,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -2048,7 +2053,7 @@
           "Name": "opel manta",
           "Origin": "Europe",
           "Weight_in_lbs": 2158,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -2059,7 +2064,7 @@
           "Name": "audi 100ls",
           "Origin": "Europe",
           "Weight_in_lbs": 2582,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -2070,7 +2075,7 @@
           "Name": "volvo 144ea",
           "Origin": "Europe",
           "Weight_in_lbs": 2868,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 11,
@@ -2081,7 +2086,7 @@
           "Name": "dodge dart custom",
           "Origin": "USA",
           "Weight_in_lbs": 3399,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -2092,7 +2097,7 @@
           "Name": "saab 99le",
           "Origin": "Europe",
           "Weight_in_lbs": 2660,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -2103,7 +2108,7 @@
           "Name": "toyota mark ii",
           "Origin": "Japan",
           "Weight_in_lbs": 2807,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 11,
@@ -2114,7 +2119,7 @@
           "Name": "oldsmobile omega",
           "Origin": "USA",
           "Weight_in_lbs": 3664,
-          "Year": "1973-01-01"
+          "Year": "1973-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -2125,7 +2130,7 @@
           "Name": "plymouth duster",
           "Origin": "USA",
           "Weight_in_lbs": 3102,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -2136,7 +2141,7 @@
           "Name": "ford maverick",
           "Origin": "USA",
           "Weight_in_lbs": 2875,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -2147,7 +2152,7 @@
           "Name": "amc hornet",
           "Origin": "USA",
           "Weight_in_lbs": 2901,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -2158,7 +2163,7 @@
           "Name": "chevrolet nova",
           "Origin": "USA",
           "Weight_in_lbs": 3336,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -2169,7 +2174,7 @@
           "Name": "datsun b210",
           "Origin": "Japan",
           "Weight_in_lbs": 1950,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -2180,7 +2185,7 @@
           "Name": "ford pinto",
           "Origin": "USA",
           "Weight_in_lbs": 2451,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 21,
@@ -2191,7 +2196,7 @@
           "Name": "toyota corolla 1200",
           "Origin": "Japan",
           "Weight_in_lbs": 1836,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -2202,7 +2207,7 @@
           "Name": "chevrolet vega",
           "Origin": "USA",
           "Weight_in_lbs": 2542,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -2213,7 +2218,7 @@
           "Name": "chevrolet chevelle malibu classic",
           "Origin": "USA",
           "Weight_in_lbs": 3781,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 18,
@@ -2224,7 +2229,7 @@
           "Name": "amc matador",
           "Origin": "USA",
           "Weight_in_lbs": 3632,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -2235,7 +2240,7 @@
           "Name": "plymouth satellite sebring",
           "Origin": "USA",
           "Weight_in_lbs": 3613,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -2246,7 +2251,7 @@
           "Name": "ford gran torino",
           "Origin": "USA",
           "Weight_in_lbs": 4141,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -2257,7 +2262,7 @@
           "Name": "buick century luxus (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4699,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -2268,7 +2273,7 @@
           "Name": "dodge coronet custom (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4457,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -2279,7 +2284,7 @@
           "Name": "ford gran torino (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4638,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -2290,7 +2295,7 @@
           "Name": "amc matador (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4257,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -2301,7 +2306,7 @@
           "Name": "audi fox",
           "Origin": "Europe",
           "Weight_in_lbs": 2219,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -2312,7 +2317,7 @@
           "Name": "volkswagen dasher",
           "Origin": "Europe",
           "Weight_in_lbs": 1963,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -2323,7 +2328,7 @@
           "Name": "opel manta",
           "Origin": "Europe",
           "Weight_in_lbs": 2300,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -2334,7 +2339,7 @@
           "Name": "toyota corona",
           "Origin": "Japan",
           "Weight_in_lbs": 1649,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -2345,7 +2350,7 @@
           "Name": "datsun 710",
           "Origin": "Japan",
           "Weight_in_lbs": 2003,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -2356,7 +2361,7 @@
           "Name": "dodge colt",
           "Origin": "USA",
           "Weight_in_lbs": 2125,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -2367,7 +2372,7 @@
           "Name": "fiat 128",
           "Origin": "Europe",
           "Weight_in_lbs": 2108,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -2378,7 +2383,7 @@
           "Name": "fiat 124 tc",
           "Origin": "Europe",
           "Weight_in_lbs": 2246,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -2389,7 +2394,7 @@
           "Name": "honda civic",
           "Origin": "Japan",
           "Weight_in_lbs": 2489,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -2400,7 +2405,7 @@
           "Name": "subaru",
           "Origin": "Japan",
           "Weight_in_lbs": 2391,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -2411,7 +2416,7 @@
           "Name": "fiat x1.9",
           "Origin": "Europe",
           "Weight_in_lbs": 2000,
-          "Year": "1974-01-01"
+          "Year": "1974-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -2422,7 +2427,7 @@
           "Name": "plymouth valiant custom",
           "Origin": "USA",
           "Weight_in_lbs": 3264,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -2433,7 +2438,7 @@
           "Name": "chevrolet nova",
           "Origin": "USA",
           "Weight_in_lbs": 3459,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 21,
@@ -2444,7 +2449,7 @@
           "Name": "mercury monarch",
           "Origin": "USA",
           "Weight_in_lbs": 3432,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 19.5,
@@ -2455,7 +2460,7 @@
           "Name": "ford maverick",
           "Origin": "USA",
           "Weight_in_lbs": 3158,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 11.5,
@@ -2466,7 +2471,7 @@
           "Name": "pontiac catalina",
           "Origin": "USA",
           "Weight_in_lbs": 4668,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -2477,7 +2482,7 @@
           "Name": "chevrolet bel air",
           "Origin": "USA",
           "Weight_in_lbs": 4440,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -2488,7 +2493,7 @@
           "Name": "plymouth grand fury",
           "Origin": "USA",
           "Weight_in_lbs": 4498,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -2499,7 +2504,7 @@
           "Name": "ford ltd",
           "Origin": "USA",
           "Weight_in_lbs": 4657,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 21,
@@ -2510,7 +2515,7 @@
           "Name": "buick century",
           "Origin": "USA",
           "Weight_in_lbs": 3907,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 18.5,
@@ -2521,7 +2526,7 @@
           "Name": "chevroelt chevelle malibu",
           "Origin": "USA",
           "Weight_in_lbs": 3897,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -2532,7 +2537,7 @@
           "Name": "amc matador",
           "Origin": "USA",
           "Weight_in_lbs": 3730,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -2543,7 +2548,7 @@
           "Name": "plymouth fury",
           "Origin": "USA",
           "Weight_in_lbs": 3785,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -2554,7 +2559,7 @@
           "Name": "buick skyhawk",
           "Origin": "USA",
           "Weight_in_lbs": 3039,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -2565,7 +2570,7 @@
           "Name": "chevrolet monza 2+2",
           "Origin": "USA",
           "Weight_in_lbs": 3221,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 12,
@@ -2576,7 +2581,7 @@
           "Name": "ford mustang ii",
           "Origin": "USA",
           "Weight_in_lbs": 3169,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -2587,7 +2592,7 @@
           "Name": "toyota corolla",
           "Origin": "Japan",
           "Weight_in_lbs": 2171,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -2598,7 +2603,7 @@
           "Name": "ford pinto",
           "Origin": "USA",
           "Weight_in_lbs": 2639,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -2609,7 +2614,7 @@
           "Name": "amc gremlin",
           "Origin": "USA",
           "Weight_in_lbs": 2914,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 18.5,
@@ -2620,7 +2625,7 @@
           "Name": "pontiac astro",
           "Origin": "USA",
           "Weight_in_lbs": 2592,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -2631,7 +2636,7 @@
           "Name": "toyota corona",
           "Origin": "Japan",
           "Weight_in_lbs": 2702,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -2642,7 +2647,7 @@
           "Name": "volkswagen dasher",
           "Origin": "Europe",
           "Weight_in_lbs": 2223,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -2653,7 +2658,7 @@
           "Name": "datsun 710",
           "Origin": "Japan",
           "Weight_in_lbs": 2545,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -2664,7 +2669,7 @@
           "Name": "ford pinto",
           "Origin": "USA",
           "Weight_in_lbs": 2984,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -2675,7 +2680,7 @@
           "Name": "volkswagen rabbit",
           "Origin": "Europe",
           "Weight_in_lbs": 1937,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -2686,7 +2691,7 @@
           "Name": "amc pacer",
           "Origin": "USA",
           "Weight_in_lbs": 3211,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -2697,7 +2702,7 @@
           "Name": "audi 100ls",
           "Origin": "Europe",
           "Weight_in_lbs": 2694,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -2708,7 +2713,7 @@
           "Name": "peugeot 504",
           "Origin": "Europe",
           "Weight_in_lbs": 2957,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -2719,7 +2724,7 @@
           "Name": "volvo 244dl",
           "Origin": "Europe",
           "Weight_in_lbs": 2945,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -2730,7 +2735,7 @@
           "Name": "saab 99le",
           "Origin": "Europe",
           "Weight_in_lbs": 2671,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 17.5,
@@ -2741,7 +2746,7 @@
           "Name": "honda civic cvcc",
           "Origin": "Japan",
           "Weight_in_lbs": 1795,
-          "Year": "1975-01-01"
+          "Year": "1975-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -2752,7 +2757,7 @@
           "Name": "fiat 131",
           "Origin": "Europe",
           "Weight_in_lbs": 2464,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 16.9,
@@ -2763,7 +2768,7 @@
           "Name": "opel 1900",
           "Origin": "Europe",
           "Weight_in_lbs": 2220,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 14.9,
@@ -2774,7 +2779,7 @@
           "Name": "capri ii",
           "Origin": "USA",
           "Weight_in_lbs": 2572,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 17.7,
@@ -2785,7 +2790,7 @@
           "Name": "dodge colt",
           "Origin": "USA",
           "Weight_in_lbs": 2255,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 15.3,
@@ -2796,7 +2801,7 @@
           "Name": "renault 12tl",
           "Origin": "Europe",
           "Weight_in_lbs": 2202,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -2807,7 +2812,7 @@
           "Name": "chevrolet chevelle malibu classic",
           "Origin": "USA",
           "Weight_in_lbs": 4215,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -2818,7 +2823,7 @@
           "Name": "dodge coronet brougham",
           "Origin": "USA",
           "Weight_in_lbs": 4190,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 13.9,
@@ -2829,7 +2834,7 @@
           "Name": "amc matador",
           "Origin": "USA",
           "Weight_in_lbs": 3962,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 12.8,
@@ -2840,7 +2845,7 @@
           "Name": "ford gran torino",
           "Origin": "USA",
           "Weight_in_lbs": 4215,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 15.4,
@@ -2851,7 +2856,7 @@
           "Name": "plymouth valiant",
           "Origin": "USA",
           "Weight_in_lbs": 3233,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -2862,7 +2867,7 @@
           "Name": "chevrolet nova",
           "Origin": "USA",
           "Weight_in_lbs": 3353,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 17.6,
@@ -2873,7 +2878,7 @@
           "Name": "ford maverick",
           "Origin": "USA",
           "Weight_in_lbs": 3012,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 17.6,
@@ -2884,7 +2889,7 @@
           "Name": "amc hornet",
           "Origin": "USA",
           "Weight_in_lbs": 3085,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 22.2,
@@ -2895,7 +2900,7 @@
           "Name": "chevrolet chevette",
           "Origin": "USA",
           "Weight_in_lbs": 2035,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 22.1,
@@ -2906,7 +2911,7 @@
           "Name": "chevrolet woody",
           "Origin": "USA",
           "Weight_in_lbs": 2164,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 14.2,
@@ -2917,7 +2922,7 @@
           "Name": "vw rabbit",
           "Origin": "Europe",
           "Weight_in_lbs": 1937,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 17.4,
@@ -2928,7 +2933,7 @@
           "Name": "honda civic",
           "Origin": "Japan",
           "Weight_in_lbs": 1795,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 17.7,
@@ -2939,7 +2944,7 @@
           "Name": "dodge aspen se",
           "Origin": "USA",
           "Weight_in_lbs": 3651,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 21,
@@ -2950,7 +2955,7 @@
           "Name": "ford granada ghia",
           "Origin": "USA",
           "Weight_in_lbs": 3574,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 16.2,
@@ -2961,7 +2966,7 @@
           "Name": "pontiac ventura sj",
           "Origin": "USA",
           "Weight_in_lbs": 3645,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 17.8,
@@ -2972,7 +2977,7 @@
           "Name": "amc pacer d/l",
           "Origin": "USA",
           "Weight_in_lbs": 3193,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 12.2,
@@ -2983,7 +2988,7 @@
           "Name": "volkswagen rabbit",
           "Origin": "Europe",
           "Weight_in_lbs": 1825,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -2994,7 +2999,7 @@
           "Name": "datsun b-210",
           "Origin": "Japan",
           "Weight_in_lbs": 1990,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 16.4,
@@ -3005,7 +3010,7 @@
           "Name": "toyota corolla",
           "Origin": "Japan",
           "Weight_in_lbs": 2155,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 13.6,
@@ -3016,7 +3021,7 @@
           "Name": "ford pinto",
           "Origin": "USA",
           "Weight_in_lbs": 2565,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 15.7,
@@ -3027,7 +3032,7 @@
           "Name": "volvo 245",
           "Origin": "Europe",
           "Weight_in_lbs": 3150,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 13.2,
@@ -3038,7 +3043,7 @@
           "Name": "plymouth volare premier v8",
           "Origin": "USA",
           "Weight_in_lbs": 3940,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 21.9,
@@ -3049,7 +3054,7 @@
           "Name": "peugeot 504",
           "Origin": "Europe",
           "Weight_in_lbs": 3270,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -3060,7 +3065,7 @@
           "Name": "toyota mark ii",
           "Origin": "Japan",
           "Weight_in_lbs": 2930,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 16.7,
@@ -3071,7 +3076,7 @@
           "Name": "mercedes-benz 280s",
           "Origin": "Europe",
           "Weight_in_lbs": 3820,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 12.1,
@@ -3082,7 +3087,7 @@
           "Name": "cadillac seville",
           "Origin": "USA",
           "Weight_in_lbs": 4380,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 12,
@@ -3093,7 +3098,7 @@
           "Name": "chevy c10",
           "Origin": "USA",
           "Weight_in_lbs": 4055,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -3104,7 +3109,7 @@
           "Name": "ford f108",
           "Origin": "USA",
           "Weight_in_lbs": 3870,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -3115,7 +3120,7 @@
           "Name": "dodge d100",
           "Origin": "USA",
           "Weight_in_lbs": 3755,
-          "Year": "1976-01-01"
+          "Year": "1976-01-01T00:00:00"
          },
          {
           "Acceleration": 18.5,
@@ -3126,7 +3131,7 @@
           "Name": "honda Accelerationord cvcc",
           "Origin": "Japan",
           "Weight_in_lbs": 2045,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 14.8,
@@ -3137,7 +3142,7 @@
           "Name": "buick opel isuzu deluxe",
           "Origin": "USA",
           "Weight_in_lbs": 2155,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 18.6,
@@ -3148,7 +3153,7 @@
           "Name": "renault 5 gtl",
           "Origin": "Europe",
           "Weight_in_lbs": 1825,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -3159,7 +3164,7 @@
           "Name": "plymouth arrow gs",
           "Origin": "USA",
           "Weight_in_lbs": 2300,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 16.8,
@@ -3170,7 +3175,7 @@
           "Name": "datsun f-10 hatchback",
           "Origin": "Japan",
           "Weight_in_lbs": 1945,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 12.5,
@@ -3181,7 +3186,7 @@
           "Name": "chevrolet caprice classic",
           "Origin": "USA",
           "Weight_in_lbs": 3880,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -3192,7 +3197,7 @@
           "Name": "oldsmobile cutlass supreme",
           "Origin": "USA",
           "Weight_in_lbs": 4060,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 13.7,
@@ -3203,7 +3208,7 @@
           "Name": "dodge monaco brougham",
           "Origin": "USA",
           "Weight_in_lbs": 4140,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 14.9,
@@ -3214,7 +3219,7 @@
           "Name": "mercury cougar brougham",
           "Origin": "USA",
           "Weight_in_lbs": 4295,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 16.4,
@@ -3225,7 +3230,7 @@
           "Name": "chevrolet concours",
           "Origin": "USA",
           "Weight_in_lbs": 3520,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 16.9,
@@ -3236,7 +3241,7 @@
           "Name": "buick skylark",
           "Origin": "USA",
           "Weight_in_lbs": 3425,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 17.7,
@@ -3247,7 +3252,7 @@
           "Name": "plymouth volare custom",
           "Origin": "USA",
           "Weight_in_lbs": 3630,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -3258,7 +3263,7 @@
           "Name": "ford granada",
           "Origin": "USA",
           "Weight_in_lbs": 3525,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 11.1,
@@ -3269,7 +3274,7 @@
           "Name": "pontiac grand prix lj",
           "Origin": "USA",
           "Weight_in_lbs": 4220,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 11.4,
@@ -3280,7 +3285,7 @@
           "Name": "chevrolet monte carlo landau",
           "Origin": "USA",
           "Weight_in_lbs": 4165,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 12.2,
@@ -3291,7 +3296,7 @@
           "Name": "chrysler cordoba",
           "Origin": "USA",
           "Weight_in_lbs": 4325,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -3302,7 +3307,7 @@
           "Name": "ford thunderbird",
           "Origin": "USA",
           "Weight_in_lbs": 4335,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -3313,7 +3318,7 @@
           "Name": "volkswagen rabbit custom",
           "Origin": "Europe",
           "Weight_in_lbs": 1940,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -3324,7 +3329,7 @@
           "Name": "pontiac sunbird coupe",
           "Origin": "USA",
           "Weight_in_lbs": 2740,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 18.2,
@@ -3335,7 +3340,7 @@
           "Name": "toyota corolla liftback",
           "Origin": "Japan",
           "Weight_in_lbs": 2265,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 15.8,
@@ -3346,7 +3351,7 @@
           "Name": "ford mustang ii 2+2",
           "Origin": "USA",
           "Weight_in_lbs": 2755,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -3357,7 +3362,7 @@
           "Name": "chevrolet chevette",
           "Origin": "USA",
           "Weight_in_lbs": 2051,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 15.9,
@@ -3368,7 +3373,7 @@
           "Name": "dodge colt m/m",
           "Origin": "USA",
           "Weight_in_lbs": 2075,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 16.4,
@@ -3379,7 +3384,7 @@
           "Name": "subaru dl",
           "Origin": "Japan",
           "Weight_in_lbs": 1985,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 14.1,
@@ -3390,7 +3395,7 @@
           "Name": "volkswagen dasher",
           "Origin": "Europe",
           "Weight_in_lbs": 2190,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -3401,7 +3406,7 @@
           "Name": "datsun 810",
           "Origin": "Japan",
           "Weight_in_lbs": 2815,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 12.8,
@@ -3412,7 +3417,7 @@
           "Name": "bmw 320i",
           "Origin": "Europe",
           "Weight_in_lbs": 2600,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 13.5,
@@ -3423,7 +3428,7 @@
           "Name": "mazda rx-4",
           "Origin": "Japan",
           "Weight_in_lbs": 2720,
-          "Year": "1977-01-01"
+          "Year": "1977-01-01T00:00:00"
          },
          {
           "Acceleration": 21.5,
@@ -3434,7 +3439,7 @@
           "Name": "volkswagen rabbit custom diesel",
           "Origin": "Europe",
           "Weight_in_lbs": 1985,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 14.4,
@@ -3445,7 +3450,7 @@
           "Name": "ford fiesta",
           "Origin": "USA",
           "Weight_in_lbs": 1800,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 19.4,
@@ -3456,7 +3461,7 @@
           "Name": "mazda glc deluxe",
           "Origin": "Japan",
           "Weight_in_lbs": 1985,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 18.6,
@@ -3467,7 +3472,7 @@
           "Name": "datsun b210 gx",
           "Origin": "Japan",
           "Weight_in_lbs": 2070,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 16.4,
@@ -3478,7 +3483,7 @@
           "Name": "honda civic cvcc",
           "Origin": "Japan",
           "Weight_in_lbs": 1800,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -3489,7 +3494,7 @@
           "Name": "oldsmobile cutlass salon brougham",
           "Origin": "USA",
           "Weight_in_lbs": 3365,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 13.2,
@@ -3500,7 +3505,7 @@
           "Name": "dodge diplomat",
           "Origin": "USA",
           "Weight_in_lbs": 3735,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 12.8,
@@ -3511,7 +3516,7 @@
           "Name": "mercury monarch ghia",
           "Origin": "USA",
           "Weight_in_lbs": 3570,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 19.2,
@@ -3522,7 +3527,7 @@
           "Name": "pontiac phoenix lj",
           "Origin": "USA",
           "Weight_in_lbs": 3535,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 18.2,
@@ -3533,7 +3538,7 @@
           "Name": "chevrolet malibu",
           "Origin": "USA",
           "Weight_in_lbs": 3155,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 15.8,
@@ -3544,7 +3549,7 @@
           "Name": "ford fairmont (auto)",
           "Origin": "USA",
           "Weight_in_lbs": 2965,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 15.4,
@@ -3555,7 +3560,7 @@
           "Name": "ford fairmont (man)",
           "Origin": "USA",
           "Weight_in_lbs": 2720,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 17.2,
@@ -3566,7 +3571,7 @@
           "Name": "plymouth volare",
           "Origin": "USA",
           "Weight_in_lbs": 3430,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 17.2,
@@ -3577,7 +3582,7 @@
           "Name": "amc concord",
           "Origin": "USA",
           "Weight_in_lbs": 3210,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 15.8,
@@ -3588,7 +3593,7 @@
           "Name": "buick century special",
           "Origin": "USA",
           "Weight_in_lbs": 3380,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 16.7,
@@ -3599,7 +3604,7 @@
           "Name": "mercury zephyr",
           "Origin": "USA",
           "Weight_in_lbs": 3070,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 18.7,
@@ -3610,7 +3615,7 @@
           "Name": "dodge aspen",
           "Origin": "USA",
           "Weight_in_lbs": 3620,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 15.1,
@@ -3621,7 +3626,7 @@
           "Name": "amc concord d/l",
           "Origin": "USA",
           "Weight_in_lbs": 3410,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 13.2,
@@ -3632,7 +3637,7 @@
           "Name": "chevrolet monte carlo landau",
           "Origin": "USA",
           "Weight_in_lbs": 3425,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 13.4,
@@ -3643,7 +3648,7 @@
           "Name": "buick regal sport coupe (turbo)",
           "Origin": "USA",
           "Weight_in_lbs": 3445,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 11.2,
@@ -3654,7 +3659,7 @@
           "Name": "ford futura",
           "Origin": "USA",
           "Weight_in_lbs": 3205,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 13.7,
@@ -3665,7 +3670,7 @@
           "Name": "dodge magnum xe",
           "Origin": "USA",
           "Weight_in_lbs": 4080,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -3676,7 +3681,7 @@
           "Name": "chevrolet chevette",
           "Origin": "USA",
           "Weight_in_lbs": 2155,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 14.2,
@@ -3687,7 +3692,7 @@
           "Name": "toyota corona",
           "Origin": "Japan",
           "Weight_in_lbs": 2560,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 14.7,
@@ -3698,7 +3703,7 @@
           "Name": "datsun 510",
           "Origin": "Japan",
           "Weight_in_lbs": 2300,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -3709,7 +3714,7 @@
           "Name": "dodge omni",
           "Origin": "USA",
           "Weight_in_lbs": 2230,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 14.8,
@@ -3720,7 +3725,7 @@
           "Name": "toyota celica gt liftback",
           "Origin": "Japan",
           "Weight_in_lbs": 2515,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 16.7,
@@ -3731,7 +3736,7 @@
           "Name": "plymouth sapporo",
           "Origin": "USA",
           "Weight_in_lbs": 2745,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 17.6,
@@ -3742,7 +3747,7 @@
           "Name": "oldsmobile starfire sx",
           "Origin": "USA",
           "Weight_in_lbs": 2855,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 14.9,
@@ -3753,7 +3758,7 @@
           "Name": "datsun 200-sx",
           "Origin": "Japan",
           "Weight_in_lbs": 2405,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 15.9,
@@ -3764,7 +3769,7 @@
           "Name": "audi 5000",
           "Origin": "Europe",
           "Weight_in_lbs": 2830,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 13.6,
@@ -3775,7 +3780,7 @@
           "Name": "volvo 264gl",
           "Origin": "Europe",
           "Weight_in_lbs": 3140,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 15.7,
@@ -3786,7 +3791,7 @@
           "Name": "saab 99gle",
           "Origin": "Europe",
           "Weight_in_lbs": 2795,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 15.8,
@@ -3797,7 +3802,7 @@
           "Name": "peugeot 604sl",
           "Origin": "Europe",
           "Weight_in_lbs": 3410,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 14.9,
@@ -3808,7 +3813,7 @@
           "Name": "volkswagen scirocco",
           "Origin": "Europe",
           "Weight_in_lbs": 1990,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 16.6,
@@ -3819,7 +3824,7 @@
           "Name": "honda Accelerationord lx",
           "Origin": "Japan",
           "Weight_in_lbs": 2135,
-          "Year": "1978-01-01"
+          "Year": "1978-01-01T00:00:00"
          },
          {
           "Acceleration": 15.4,
@@ -3830,7 +3835,7 @@
           "Name": "pontiac lemans v6",
           "Origin": "USA",
           "Weight_in_lbs": 3245,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 18.2,
@@ -3841,7 +3846,7 @@
           "Name": "mercury zephyr 6",
           "Origin": "USA",
           "Weight_in_lbs": 2990,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 17.3,
@@ -3852,7 +3857,7 @@
           "Name": "ford fairmont 4",
           "Origin": "USA",
           "Weight_in_lbs": 2890,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 18.2,
@@ -3863,7 +3868,7 @@
           "Name": "amc concord dl 6",
           "Origin": "USA",
           "Weight_in_lbs": 3265,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 16.6,
@@ -3874,7 +3879,7 @@
           "Name": "dodge aspen 6",
           "Origin": "USA",
           "Weight_in_lbs": 3360,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 15.4,
@@ -3885,7 +3890,7 @@
           "Name": "chevrolet caprice classic",
           "Origin": "USA",
           "Weight_in_lbs": 3840,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 13.4,
@@ -3896,7 +3901,7 @@
           "Name": "ford ltd landau",
           "Origin": "USA",
           "Weight_in_lbs": 3725,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 13.2,
@@ -3907,7 +3912,7 @@
           "Name": "mercury grand marquis",
           "Origin": "USA",
           "Weight_in_lbs": 3955,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 15.2,
@@ -3918,7 +3923,7 @@
           "Name": "dodge st. regis",
           "Origin": "USA",
           "Weight_in_lbs": 3830,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 14.9,
@@ -3929,7 +3934,7 @@
           "Name": "buick estate wagon (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4360,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 14.3,
@@ -3940,7 +3945,7 @@
           "Name": "ford country squire (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 4054,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -3951,7 +3956,7 @@
           "Name": "chevrolet malibu classic (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 3605,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -3962,7 +3967,7 @@
           "Name": "chrysler lebaron town @ country (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 3940,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 14,
@@ -3973,7 +3978,7 @@
           "Name": "vw rabbit custom",
           "Origin": "Europe",
           "Weight_in_lbs": 1925,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 15.2,
@@ -3984,7 +3989,7 @@
           "Name": "maxda glc deluxe",
           "Origin": "Japan",
           "Weight_in_lbs": 1975,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 14.4,
@@ -3995,7 +4000,7 @@
           "Name": "dodge colt hatchback custom",
           "Origin": "USA",
           "Weight_in_lbs": 1915,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -4006,7 +4011,7 @@
           "Name": "amc spirit dl",
           "Origin": "USA",
           "Weight_in_lbs": 2670,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 20.1,
@@ -4017,7 +4022,7 @@
           "Name": "mercedes benz 300d",
           "Origin": "Europe",
           "Weight_in_lbs": 3530,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 17.4,
@@ -4028,7 +4033,7 @@
           "Name": "cadillac eldorado",
           "Origin": "USA",
           "Weight_in_lbs": 3900,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 24.8,
@@ -4039,7 +4044,7 @@
           "Name": "peugeot 504",
           "Origin": "Europe",
           "Weight_in_lbs": 3190,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 22.2,
@@ -4050,7 +4055,7 @@
           "Name": "oldsmobile cutlass salon brougham",
           "Origin": "USA",
           "Weight_in_lbs": 3420,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 13.2,
@@ -4061,7 +4066,7 @@
           "Name": "plymouth horizon",
           "Origin": "USA",
           "Weight_in_lbs": 2200,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 14.9,
@@ -4072,7 +4077,7 @@
           "Name": "plymouth horizon tc3",
           "Origin": "USA",
           "Weight_in_lbs": 2150,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 19.2,
@@ -4083,7 +4088,7 @@
           "Name": "datsun 210",
           "Origin": "Japan",
           "Weight_in_lbs": 2020,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 14.7,
@@ -4094,7 +4099,7 @@
           "Name": "fiat strada custom",
           "Origin": "Europe",
           "Weight_in_lbs": 2130,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -4105,7 +4110,7 @@
           "Name": "buick skylark limited",
           "Origin": "USA",
           "Weight_in_lbs": 2670,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 11.3,
@@ -4116,7 +4121,7 @@
           "Name": "chevrolet citation",
           "Origin": "USA",
           "Weight_in_lbs": 2595,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 12.9,
@@ -4127,7 +4132,7 @@
           "Name": "oldsmobile omega brougham",
           "Origin": "USA",
           "Weight_in_lbs": 2700,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 13.2,
@@ -4138,7 +4143,7 @@
           "Name": "pontiac phoenix",
           "Origin": "USA",
           "Weight_in_lbs": 2556,
-          "Year": "1979-01-01"
+          "Year": "1979-01-01T00:00:00"
          },
          {
           "Acceleration": 14.7,
@@ -4149,7 +4154,7 @@
           "Name": "vw rabbit",
           "Origin": "Europe",
           "Weight_in_lbs": 2144,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 18.8,
@@ -4160,7 +4165,7 @@
           "Name": "toyota corolla tercel",
           "Origin": "Japan",
           "Weight_in_lbs": 1968,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -4171,7 +4176,7 @@
           "Name": "chevrolet chevette",
           "Origin": "USA",
           "Weight_in_lbs": 2120,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 16.4,
@@ -4182,7 +4187,7 @@
           "Name": "datsun 310",
           "Origin": "Japan",
           "Weight_in_lbs": 2019,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 16.5,
@@ -4193,7 +4198,7 @@
           "Name": "chevrolet citation",
           "Origin": "USA",
           "Weight_in_lbs": 2678,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 18.1,
@@ -4204,7 +4209,7 @@
           "Name": "ford fairmont",
           "Origin": "USA",
           "Weight_in_lbs": 2870,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 20.1,
@@ -4215,7 +4220,7 @@
           "Name": "amc concord",
           "Origin": "USA",
           "Weight_in_lbs": 3003,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 18.7,
@@ -4226,7 +4231,7 @@
           "Name": "dodge aspen",
           "Origin": "USA",
           "Weight_in_lbs": 3381,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 15.8,
@@ -4237,7 +4242,7 @@
           "Name": "audi 4000",
           "Origin": "Europe",
           "Weight_in_lbs": 2188,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 15.5,
@@ -4248,7 +4253,7 @@
           "Name": "toyota corona liftback",
           "Origin": "Japan",
           "Weight_in_lbs": 2711,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 17.5,
@@ -4259,7 +4264,7 @@
           "Name": "mazda 626",
           "Origin": "Japan",
           "Weight_in_lbs": 2542,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -4270,7 +4275,7 @@
           "Name": "datsun 510 hatchback",
           "Origin": "Japan",
           "Weight_in_lbs": 2434,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 15.2,
@@ -4281,7 +4286,7 @@
           "Name": "toyota corolla",
           "Origin": "Japan",
           "Weight_in_lbs": 2265,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 17.9,
@@ -4292,7 +4297,7 @@
           "Name": "mazda glc",
           "Origin": "Japan",
           "Weight_in_lbs": 2110,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 14.4,
@@ -4303,7 +4308,7 @@
           "Name": "dodge colt",
           "Origin": "USA",
           "Weight_in_lbs": 2800,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 19.2,
@@ -4314,7 +4319,7 @@
           "Name": "datsun 210",
           "Origin": "Japan",
           "Weight_in_lbs": 2110,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 21.7,
@@ -4325,7 +4330,7 @@
           "Name": "vw rabbit c (diesel)",
           "Origin": "Europe",
           "Weight_in_lbs": 2085,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 23.7,
@@ -4336,7 +4341,7 @@
           "Name": "vw dasher (diesel)",
           "Origin": "Europe",
           "Weight_in_lbs": 2335,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 19.9,
@@ -4347,7 +4352,7 @@
           "Name": "audi 5000s (diesel)",
           "Origin": "Europe",
           "Weight_in_lbs": 2950,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 21.8,
@@ -4358,7 +4363,7 @@
           "Name": "mercedes-benz 240d",
           "Origin": "Europe",
           "Weight_in_lbs": 3250,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 13.8,
@@ -4369,7 +4374,7 @@
           "Name": "honda civic 1500 gl",
           "Origin": "Japan",
           "Weight_in_lbs": 1850,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 17.3,
@@ -4380,7 +4385,7 @@
           "Name": "renault lecar deluxe",
           "Origin": "Europe",
           "Weight_in_lbs": 1835,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 18,
@@ -4391,7 +4396,7 @@
           "Name": "subaru dl",
           "Origin": "Japan",
           "Weight_in_lbs": 2145,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 15.3,
@@ -4402,7 +4407,7 @@
           "Name": "vokswagen rabbit",
           "Origin": "Europe",
           "Weight_in_lbs": 1845,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 11.4,
@@ -4413,7 +4418,7 @@
           "Name": "datsun 280-zx",
           "Origin": "Japan",
           "Weight_in_lbs": 2910,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 12.5,
@@ -4424,7 +4429,7 @@
           "Name": "mazda rx-7 gs",
           "Origin": "Japan",
           "Weight_in_lbs": 2420,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 15.1,
@@ -4435,7 +4440,7 @@
           "Name": "triumph tr7 coupe",
           "Origin": "Europe",
           "Weight_in_lbs": 2500,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 14.3,
@@ -4446,7 +4451,7 @@
           "Name": "ford mustang cobra",
           "Origin": "USA",
           "Weight_in_lbs": 2905,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -4457,7 +4462,7 @@
           "Name": "honda Accelerationord",
           "Origin": "Japan",
           "Weight_in_lbs": 2290,
-          "Year": "1980-01-01"
+          "Year": "1980-01-01T00:00:00"
          },
          {
           "Acceleration": 15.7,
@@ -4468,7 +4473,7 @@
           "Name": "plymouth reliant",
           "Origin": "USA",
           "Weight_in_lbs": 2490,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.4,
@@ -4479,7 +4484,7 @@
           "Name": "buick skylark",
           "Origin": "USA",
           "Weight_in_lbs": 2635,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.4,
@@ -4490,7 +4495,7 @@
           "Name": "dodge aries wagon (sw)",
           "Origin": "USA",
           "Weight_in_lbs": 2620,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 12.6,
@@ -4501,7 +4506,7 @@
           "Name": "chevrolet citation",
           "Origin": "USA",
           "Weight_in_lbs": 2725,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 12.9,
@@ -4512,7 +4517,7 @@
           "Name": "plymouth reliant",
           "Origin": "USA",
           "Weight_in_lbs": 2385,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.9,
@@ -4523,7 +4528,7 @@
           "Name": "toyota starlet",
           "Origin": "Japan",
           "Weight_in_lbs": 1755,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.4,
@@ -4534,7 +4539,7 @@
           "Name": "plymouth champ",
           "Origin": "USA",
           "Weight_in_lbs": 1875,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.1,
@@ -4545,7 +4550,7 @@
           "Name": "honda civic 1300",
           "Origin": "Japan",
           "Weight_in_lbs": 1760,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 17.8,
@@ -4556,7 +4561,7 @@
           "Name": "subaru",
           "Origin": "Japan",
           "Weight_in_lbs": 2065,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 19.4,
@@ -4567,7 +4572,7 @@
           "Name": "datsun 210",
           "Origin": "Japan",
           "Weight_in_lbs": 1975,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 17.3,
@@ -4578,7 +4583,7 @@
           "Name": "toyota tercel",
           "Origin": "Japan",
           "Weight_in_lbs": 2050,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -4589,7 +4594,7 @@
           "Name": "mazda glc 4",
           "Origin": "Japan",
           "Weight_in_lbs": 1985,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.9,
@@ -4600,7 +4605,7 @@
           "Name": "plymouth horizon 4",
           "Origin": "USA",
           "Weight_in_lbs": 2215,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.2,
@@ -4611,7 +4616,7 @@
           "Name": "ford escort 4w",
           "Origin": "USA",
           "Weight_in_lbs": 2045,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 20.7,
@@ -4622,7 +4627,7 @@
           "Name": "ford escort 2h",
           "Origin": "USA",
           "Weight_in_lbs": 2380,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.2,
@@ -4633,7 +4638,7 @@
           "Name": "volkswagen jetta",
           "Origin": "Europe",
           "Weight_in_lbs": 2190,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 15.8,
@@ -4644,7 +4649,7 @@
           "Name": "renault 18i",
           "Origin": "Europe",
           "Weight_in_lbs": 2320,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.4,
@@ -4655,7 +4660,7 @@
           "Name": "honda prelude",
           "Origin": "Japan",
           "Weight_in_lbs": 2210,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.8,
@@ -4666,7 +4671,7 @@
           "Name": "toyota corolla",
           "Origin": "Japan",
           "Weight_in_lbs": 2350,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.8,
@@ -4677,7 +4682,7 @@
           "Name": "datsun 200sx",
           "Origin": "Japan",
           "Weight_in_lbs": 2615,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 18.3,
@@ -4688,7 +4693,7 @@
           "Name": "mazda 626",
           "Origin": "Japan",
           "Weight_in_lbs": 2635,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 20.4,
@@ -4699,7 +4704,7 @@
           "Name": "peugeot 505s turbo diesel",
           "Origin": "Europe",
           "Weight_in_lbs": 3230,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 15.4,
@@ -4710,7 +4715,7 @@
           "Name": "saab 900s",
           "Origin": "Europe",
           "Weight_in_lbs": 2800,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 19.6,
@@ -4721,7 +4726,7 @@
           "Name": "volvo diesel",
           "Origin": "Europe",
           "Weight_in_lbs": 3160,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 12.6,
@@ -4732,7 +4737,7 @@
           "Name": "toyota cressida",
           "Origin": "Japan",
           "Weight_in_lbs": 2900,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 13.8,
@@ -4743,7 +4748,7 @@
           "Name": "datsun 810 maxima",
           "Origin": "Japan",
           "Weight_in_lbs": 2930,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 15.8,
@@ -4754,7 +4759,7 @@
           "Name": "buick century",
           "Origin": "USA",
           "Weight_in_lbs": 3415,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 19,
@@ -4765,7 +4770,7 @@
           "Name": "oldsmobile cutlass ls",
           "Origin": "USA",
           "Weight_in_lbs": 3725,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 17.1,
@@ -4776,7 +4781,7 @@
           "Name": "ford granada gl",
           "Origin": "USA",
           "Weight_in_lbs": 3060,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.6,
@@ -4787,7 +4792,7 @@
           "Name": "chrysler lebaron salon",
           "Origin": "USA",
           "Weight_in_lbs": 3465,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 19.6,
@@ -4798,7 +4803,7 @@
           "Name": "chevrolet cavalier",
           "Origin": "USA",
           "Weight_in_lbs": 2605,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 18.6,
@@ -4809,7 +4814,7 @@
           "Name": "chevrolet cavalier wagon",
           "Origin": "USA",
           "Weight_in_lbs": 2640,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 18,
@@ -4820,7 +4825,7 @@
           "Name": "chevrolet cavalier 2-door",
           "Origin": "USA",
           "Weight_in_lbs": 2395,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.2,
@@ -4831,7 +4836,7 @@
           "Name": "pontiac j2000 se hatchback",
           "Origin": "USA",
           "Weight_in_lbs": 2575,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16,
@@ -4842,7 +4847,7 @@
           "Name": "dodge aries se",
           "Origin": "USA",
           "Weight_in_lbs": 2525,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 18,
@@ -4853,7 +4858,7 @@
           "Name": "pontiac phoenix",
           "Origin": "USA",
           "Weight_in_lbs": 2735,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.4,
@@ -4864,7 +4869,7 @@
           "Name": "ford fairmont futura",
           "Origin": "USA",
           "Weight_in_lbs": 2865,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 20.5,
@@ -4875,7 +4880,7 @@
           "Name": "amc concord dl",
           "Origin": "USA",
           "Weight_in_lbs": 3035,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 15.3,
@@ -4886,7 +4891,7 @@
           "Name": "volkswagen rabbit l",
           "Origin": "Europe",
           "Weight_in_lbs": 1980,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 18.2,
@@ -4897,7 +4902,7 @@
           "Name": "mazda glc custom l",
           "Origin": "Japan",
           "Weight_in_lbs": 2025,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 17.6,
@@ -4908,7 +4913,7 @@
           "Name": "mazda glc custom",
           "Origin": "Japan",
           "Weight_in_lbs": 1970,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.7,
@@ -4919,7 +4924,7 @@
           "Name": "plymouth horizon miser",
           "Origin": "USA",
           "Weight_in_lbs": 2125,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 17.3,
@@ -4930,7 +4935,7 @@
           "Name": "mercury lynx l",
           "Origin": "USA",
           "Weight_in_lbs": 2125,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -4941,7 +4946,7 @@
           "Name": "nissan stanza xe",
           "Origin": "Japan",
           "Weight_in_lbs": 2160,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -4952,7 +4957,7 @@
           "Name": "honda Accelerationord",
           "Origin": "Japan",
           "Weight_in_lbs": 2205,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.9,
@@ -4963,7 +4968,7 @@
           "Name": "toyota corolla",
           "Origin": "Japan",
           "Weight_in_lbs": 2245,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 15,
@@ -4974,7 +4979,7 @@
           "Name": "honda civic",
           "Origin": "Japan",
           "Weight_in_lbs": 1965,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 15.7,
@@ -4985,7 +4990,7 @@
           "Name": "honda civic (auto)",
           "Origin": "Japan",
           "Weight_in_lbs": 1965,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.2,
@@ -4996,7 +5001,7 @@
           "Name": "datsun 310 gx",
           "Origin": "Japan",
           "Weight_in_lbs": 1995,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 16.4,
@@ -5007,7 +5012,7 @@
           "Name": "buick century limited",
           "Origin": "USA",
           "Weight_in_lbs": 2945,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 17,
@@ -5018,7 +5023,7 @@
           "Name": "oldsmobile cutlass ciera (diesel)",
           "Origin": "USA",
           "Weight_in_lbs": 3015,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.5,
@@ -5029,7 +5034,7 @@
           "Name": "chrysler lebaron medallion",
           "Origin": "USA",
           "Weight_in_lbs": 2585,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 14.7,
@@ -5040,7 +5045,7 @@
           "Name": "ford granada l",
           "Origin": "USA",
           "Weight_in_lbs": 2835,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 13.9,
@@ -5051,7 +5056,7 @@
           "Name": "toyota celica gt",
           "Origin": "Japan",
           "Weight_in_lbs": 2665,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 13,
@@ -5062,7 +5067,7 @@
           "Name": "dodge charger 2.2",
           "Origin": "USA",
           "Weight_in_lbs": 2370,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 17.3,
@@ -5073,7 +5078,7 @@
           "Name": "chevrolet camaro",
           "Origin": "USA",
           "Weight_in_lbs": 2950,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 15.6,
@@ -5084,7 +5089,7 @@
           "Name": "ford mustang gl",
           "Origin": "USA",
           "Weight_in_lbs": 2790,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 24.6,
@@ -5095,7 +5100,7 @@
           "Name": "vw pickup",
           "Origin": "Europe",
           "Weight_in_lbs": 2130,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 11.6,
@@ -5106,7 +5111,7 @@
           "Name": "dodge rampage",
           "Origin": "USA",
           "Weight_in_lbs": 2295,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 18.6,
@@ -5117,7 +5122,7 @@
           "Name": "ford ranger",
           "Origin": "USA",
           "Weight_in_lbs": 2625,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          },
          {
           "Acceleration": 19.4,
@@ -5128,7 +5133,7 @@
           "Name": "chevy s-10",
           "Origin": "USA",
           "Weight_in_lbs": 2720,
-          "Year": "1982-01-01"
+          "Year": "1982-01-01T00:00:00"
          }
         ]
        },
@@ -5194,7 +5199,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5.2.0\n"
+      "5.3.0\n"
      ]
     }
    ],
@@ -5241,7 +5246,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.8.0\n"
+      "1.11.0\n"
      ]
     }
    ],
@@ -5259,22 +5264,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading data from https://s3.amazonaws.com/img-datasets/mnist.npz\n",
-      "11493376/11490434 [==============================] - 4s 0us/step\n",
       "60000 train samples\n",
       "10000 test samples\n",
       "_________________________________________________________________\n",
       "Layer (type)                 Output Shape              Param #   \n",
       "=================================================================\n",
-      "dense_1 (Dense)              (None, 512)               401920    \n",
+      "dense (Dense)                (None, 512)               401920    \n",
+      "_________________________________________________________________\n",
+      "dropout (Dropout)            (None, 512)               0         \n",
+      "_________________________________________________________________\n",
+      "dense_1 (Dense)              (None, 512)               262656    \n",
       "_________________________________________________________________\n",
       "dropout_1 (Dropout)          (None, 512)               0         \n",
       "_________________________________________________________________\n",
-      "dense_2 (Dense)              (None, 512)               262656    \n",
-      "_________________________________________________________________\n",
-      "dropout_2 (Dropout)          (None, 512)               0         \n",
-      "_________________________________________________________________\n",
-      "dense_3 (Dense)              (None, 10)                5130      \n",
+      "dense_2 (Dense)              (None, 10)                5130      \n",
       "=================================================================\n",
       "Total params: 669,706\n",
       "Trainable params: 669,706\n",
@@ -5282,11 +5285,11 @@
       "_________________________________________________________________\n",
       "Train on 60000 samples, validate on 10000 samples\n",
       "Epoch 1/2\n",
-      "60000/60000 [==============================] - 7s 123us/step - loss: 0.2452 - acc: 0.9247 - val_loss: 0.1031 - val_acc: 0.9674\n",
+      "60000/60000 [==============================] - 10s 167us/step - loss: 0.2472 - acc: 0.9250 - val_loss: 0.1041 - val_acc: 0.9678\n",
       "Epoch 2/2\n",
-      "60000/60000 [==============================] - 7s 117us/step - loss: 0.1014 - acc: 0.9687 - val_loss: 0.0825 - val_acc: 0.9747\n",
-      "Test loss: 0.0825320691193\n",
-      "Test accuracy: 0.9747\n"
+      "60000/60000 [==============================] - 8s 128us/step - loss: 0.1024 - acc: 0.9690 - val_loss: 0.0811 - val_acc: 0.9746\n",
+      "Test loss: 0.0811092196516\n",
+      "Test accuracy: 0.9746\n"
      ]
     }
    ],
@@ -5339,6 +5342,13 @@
     "print('Test loss:', score[0])\n",
     "print('Test accuracy:', score[1])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -5357,7 +5367,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Base image: jupyter/scipy-notebook -> 11/6/2018 version
Altair 2.1.0 -> 2.2.2
bqplot 0.11.0 -> 0.11.2
earthengine-api 0.1.145 -> 0.1.152
google-api-python 1.6.7 -> 1.7.4
ipyleaflet 0.9.0 -> 0.9.1
ipyvolume 0.4.6 -> 0.5.1
widgets-jupyterlab-manager 0.36.2 -> 0.38.1
nbdime 1.0.2 -> 1.0.3
tensorflow 1.8.0 -> 1.11.0